### PR TITLE
add special case for ^D

### DIFF
--- a/line.go
+++ b/line.go
@@ -46,10 +46,6 @@ const (
 	unknown
 )
 
-var (
-	ErrExitMainLoop error = errors.New("Exit main loop")
-)
-
 type commonState struct {
 	history   []string
 	supported bool
@@ -308,7 +304,7 @@ mainLoop:
 			case ctrlD: // del
 				if pos == 0 && len(line) == 0 {
 					// exit
-					return "", ErrExitMainLoop
+					return "", io.EOF
 				}
 				if pos >= len(line) {
 					fmt.Print(beep)


### PR DESCRIPTION
usually in REPL loops, ^D on an empty line exits the interpreter.
this changeset adds this feature.
(perhaps in a rather crude way...)

sebastien.
