### PR TITLE
Stop prompt attempts on non-terminal stdout

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,17 +7,21 @@ package liner
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"unicode/utf8"
 )
 
 type commonState struct {
-	history   []string
-	supported bool
-	completer Completer
-	columns   int
+	terminalSupported bool
+	terminalOutput    bool
+	history           []string
+	completer         Completer
+	columns           int
 }
+
+var errNotTerminalOutput = errors.New("standard output is not a terminal")
 
 // HistoryLimit is the maximum number of entries saved in the scrollback history.
 const HistoryLimit = 1000

--- a/input_windows.go
+++ b/input_windows.go
@@ -55,6 +55,7 @@ func NewLiner() *State {
 	hOut, _, _ := procGetStdHandle.Call(uintptr(std_output_handle))
 	s.hOut = syscall.Handle(hOut)
 
+	s.terminalSupported = true
 	ok, _, _ := procGetConsoleMode.Call(hIn, uintptr(unsafe.Pointer(&s.origMode)))
 	if ok != 0 {
 		mode := s.origMode
@@ -66,7 +67,9 @@ func NewLiner() *State {
 		procSetConsoleMode.Call(hIn, uintptr(mode))
 	}
 
-	s.supported = true
+	s.getColumns()
+	s.terminalOutput = s.columns > 0
+
 	return &s
 }
 

--- a/line.go
+++ b/line.go
@@ -169,7 +169,10 @@ func (s *State) tabComplete(p string, line []rune) ([]rune, interface{}, error) 
 // Prompt displays p, and then waits for user input. Prompt allows line editing
 // if the terminal supports it.
 func (s *State) Prompt(p string) (string, error) {
-	if !s.supported {
+	if !s.terminalOutput {
+		return "", errNotTerminalOutput
+	}
+	if !s.terminalSupported {
 		return s.promptUnsupported(p)
 	}
 


### PR DESCRIPTION
Hi - thanks for the cool package. I noticed that it's assumed that standard output is a terminal if the parent has set TERM, but that doesn't hold when shell output redirection is used. Before my changes, *State.refresh will panic in case (C) due to trying to work out how to maintain the line editor in the non-existent columns of a normal file.

I don't think my changes mess anything else up, but let me know what you think.

```
Desktop $ cat x.go
package main

import (
    "fmt"
    "strconv"

    "github.com/frou/liner"
)

func main() {
    ln := liner.NewLiner()
    defer ln.Close()

    var accum int
    for {
        s, err := ln.Prompt("$ ")
        if err != nil {
            fmt.Println("error:", err)
            return
        }

        n, _ := strconv.Atoi(s)
        accum += n
        fmt.Println(accum)
    }
}

(A)
Desktop $ go run x.go
$ 2
2
$ 4
6
$ 8
14
$ error: EOF

Desktop $ cat >input.txt
3
9
27

(B)
Desktop $ go run x.go <input.txt
$ 3
3
$ 9
12
$ 27
39
$ error: EOF

(C)
Desktop $ go run x.go <input.txt >output.txt
Desktop $ cat output.txt
error: standard output is not a terminal
```
