### PR TITLE
Switching oh to liner

### DIFF
--- a/common.go
+++ b/common.go
@@ -14,6 +14,7 @@ import (
 )
 
 type commonState struct {
+	terminalSupported bool
 	terminalOutput    bool
 	history           []string
 	completer         Completer

--- a/input.go
+++ b/input.go
@@ -3,15 +3,16 @@
 package liner
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
-	"io"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
-	"unicode/utf8"
 	"unsafe"
 )
 
@@ -23,7 +24,7 @@ type nexter struct {
 // State represents an open terminal
 type State struct {
 	commonState
-	r        *readRune
+	r        *bufio.Reader
 	editMode termios
 	origMode termios
 	next     <-chan nexter
@@ -31,79 +32,14 @@ type State struct {
 	pending  []rune
 }
 
-// The readRune structure and methods copied from src/pkg/fmt/scan.go:
-// readRune is a structure to enable reading UTF-8 encoded code points
-// from an io.Reader.  It is used if the Reader given to the scanner does
-// not already implement io.RuneReader.
-type readRune struct {
-	reader  io.Reader
-  	buf	[utf8.UTFMax]byte // used only inside ReadRune
-	pending int               // number of bytes in pendBuf; only >0 for bad UTF-8
-	pendBuf [utf8.UTFMax]byte // bytes left over
-}
-
-// readByte returns the next byte from the input, which may be
-// left over from a previous read if the UTF-8 was ill-formed.
-func (r *readRune) readByte() (b byte, err error) {
-	if r.pending > 0 {
-		b = r.pendBuf[0]
-		copy(r.pendBuf[0:], r.pendBuf[1:])
-		r.pending--
-		return
-	}
-	n, err := io.ReadFull(r.reader, r.pendBuf[0:1])
-	if n != 1 {
-		return 0, err
-	}
-	return r.pendBuf[0], err
-}
-
-// unread saves the bytes for the next read.
-func (r *readRune) unread(buf []byte) {
-	copy(r.pendBuf[r.pending:], buf)
-	r.pending += len(buf)
-}
-
-// ReadRune returns the next UTF-8 encoded code point from the
-// io.Reader inside r.
-func (r *readRune) ReadRune() (rr rune, size int, err error) {
-	r.buf[0], err = r.readByte()
-	if err != nil {
-		return 0, 0, err
-	}
-	if r.buf[0] < utf8.RuneSelf { // fast check for common ASCII case
-		rr = rune(r.buf[0])
-		return
-	}
-	var n int
-	for n = 1; !utf8.FullRune(r.buf[0:n]); n++ {
-		r.buf[n], err = r.readByte()
-		if err != nil {
-			if err == io.EOF {
-				err = nil
-				break
-			}
-			return
-		}
-	}
-	rr, size = utf8.DecodeRune(r.buf[0:n])
-	if size < n { // an error
-		r.unread(r.buf[size:n])
-	}
-	return
-}
-
-func UnsupportedTerminal() bool {
-	term := os.Getenv("TERM")
+func TerminalSupported() bool {
 	bad := map[string]bool{"": true, "dumb": true, "cons25": true}
-	if bad[strings.ToLower(term)] {
-		return true
-	}
-	return false
+	return !bad[strings.ToLower(os.Getenv("TERM"))]
 }
 
-// NewLiner initializes a new *State, and saves the previous terminal mode.
-// To restore the terminal to its previous state, call State.Close().
+// NewLiner initializes a new *State, saves the previous terminal mode and
+// sets the terminal into raw mode. To restore the terminal to its previous
+// state, call State.Close().
 //
 // Note if you are still using Go 1.0: NewLiner handles SIGWINCH, so it will
 // leak a channel every time you call it. Therefore, it is recommened that you
@@ -112,22 +48,24 @@ func UnsupportedTerminal() bool {
 func NewLiner() *State {
 	var s State
 
-	s.r = &readRune{reader: os.Stdin}
+	s.r = bufio.NewReader(os.Stdin)
 
-	if UnsupportedTerminal() {
-		panic("liner: unsupported terminal type")
-	}
+	s.terminalSupported = TerminalSupported()
 
-	syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin),
+	if s.terminalSupported {
+		syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin),
 			getTermios, uintptr(unsafe.Pointer(&s.origMode)))
 
-	s.editMode = s.origMode
-	s.editMode.Iflag &^= icrnl | inpck | istrip | ixon
-	s.editMode.Cflag |= cs8
-	s.editMode.Lflag &^= syscall.ECHO | icanon | iexten
+		s.editMode = s.origMode
+		s.editMode.Iflag &^= icrnl | inpck | istrip | ixon
+		s.editMode.Cflag |= cs8
+		s.editMode.Lflag &^= syscall.ECHO | icanon | iexten
 
-	s.winch = make(chan os.Signal, 1)
-	signal.Notify(s.winch, syscall.SIGWINCH)
+		s.LineEditingMode()
+
+		s.winch = make(chan os.Signal, 1)
+		signal.Notify(s.winch, syscall.SIGWINCH)
+	}
 
 	s.getColumns()
 	s.terminalOutput = s.columns > 0
@@ -372,32 +310,39 @@ func (s *State) readNext() (interface{}, error) {
 	return r, nil
 }
 
+func (s *State) promptUnsupported(p string) (string, error) {
+	fmt.Print(p)
+	linebuf, _, err := s.r.ReadLine()
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(linebuf)), nil
+}
+
 func (s *State) Close() error {
 	if s != nil {
 		stopSignal(s.winch)
-		s.restoreTerminalMode()
+		s.OriginalTerminalMode()
 	}
-
 	return nil
 }
 
-// Return the terminal to its original mode.
-func (s *State) restoreTerminalMode() {
-	if s == nil {
-		return
-	}
-
-	syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin),
-			setTermios, uintptr(unsafe.Pointer(&s.origMode)))
-}
-
 // Put the terminal into the mode required for line editing.
-func (s *State) lineEditingMode() {
-	if s == nil {
+func (s *State) LineEditingMode() {
+	if s == nil || !s.terminalSupported {
 		return
 	}
 
 	syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin),
-			setTermios, uintptr(unsafe.Pointer(&s.editMode)))
+		setTermios, uintptr(unsafe.Pointer(&s.editMode)))
 }
 
+// Return the terminal to its original mode.
+func (s *State) OriginalTerminalMode() {
+	if s == nil || !s.terminalSupported {
+		return
+	}
+
+	syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin),
+		setTermios, uintptr(unsafe.Pointer(&s.origMode)))
+}

--- a/line.go
+++ b/line.go
@@ -44,25 +44,25 @@ const (
 )
 
 const (
-	ctrlA = 1
-	ctrlB = 2
-	ctrlC = 3
-	ctrlD = 4
-	ctrlE = 5
-	ctrlF = 6
-	ctrlH = 8
+	ctrlA  = 1
+	ctrlB  = 2
+	ctrlC  = 3
+	ctrlD  = 4
+	ctrlE  = 5
+	ctrlF  = 6
+	ctrlH  = 8
 	tabKey = 9
-	lf    = 10
-	ctrlK = 11
-	ctrlL = 12
-	cr    = 13
-	ctrlN = 14
-	ctrlP = 16
-	ctrlT = 20
-	ctrlU = 21
-	ctrlW = 23
-	escKey   = 27
-	bs    = 127
+	lf     = 10
+	ctrlK  = 11
+	ctrlL  = 12
+	cr     = 13
+	ctrlN  = 14
+	ctrlP  = 16
+	ctrlT  = 20
+	ctrlU  = 21
+	ctrlW  = 23
+	escKey = 27
+	bs     = 127
 )
 
 const (
@@ -174,9 +174,9 @@ func (s *State) Prompt(p string) (string, error) {
 	if !s.terminalOutput {
 		return "", errNotTerminalOutput
 	}
-
-	defer s.restoreTerminalMode()
-	s.lineEditingMode()
+	if !s.terminalSupported {
+		return s.promptUnsupported(p)
+	}
 
 	s.startPrompt()
 	s.getColumns()


### PR DESCRIPTION
Hi Peter,

I recently modified my shell (https://github.com/michaelmacinnis/oh) to use your liner line editing library.

I had to make a few modifications. You may not be interested in these changes but I thought I would send a pull request anyway.
### Losing characters

Because I'm sharing the terminal with other applications I can't use bufio (unless you know how to stop it from stealing characters). I've modified liner to use unbuffered input and copied the readRune structure and methods from src/pkg/fmt/scan.go
### Terminal mode problems

Sharing the terminal with other applications also causes problems for programs that expect the terminal to be in canonical mode. I changed Prompt to set the terminal mode before prompting and restore it after reading a line.
### Unsupported terminals

Using unbuffered input and setting/resetting the terminal mode mode make it seem less likely that one would want to use liner on an unsupported terminal. I changed NewLiner to panic on an unsupported terminal and exposed UnsupportedTerminal to allow callers to check if the terminal is supported before calling NewLiner.
### Auto-complete if there is only one completion

I've changed tabComplete to automatically return the completion if there is only a single completion.
### Tab and shift-tab cycle through completions

I also changed tabComplete so that tab and shift-tab cycle through completions.
### Windows

I don't have a Windows development machine for testing but I have attempted to keep the Windows version in sync.

Thanks for writing liner!

Michael.
