### PR TITLE
Renamed termios type to TerminalMode. Added GetTerminalMode, GetOriginal...

### DIFF
--- a/input.go
+++ b/input.go
@@ -25,7 +25,7 @@ type nexter struct {
 type State struct {
 	commonState
 	r        *bufio.Reader
-	origMode termios
+	origMode TerminalMode
 	next     <-chan nexter
 	winch    chan os.Signal
 	pending  []rune
@@ -39,18 +39,17 @@ type State struct {
 // upgrade to a newer release of Go, or ensure that NewLiner is only called
 // once.
 func NewLiner() *State {
-	bad := map[string]bool{"": true, "dumb": true, "cons25": true}
 	var s State
 	s.r = bufio.NewReader(os.Stdin)
 
-	s.terminalSupported = !bad[strings.ToLower(os.Getenv("TERM"))]
+	s.terminalSupported = TerminalSupported()
 	if s.terminalSupported {
-		syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), getTermios, uintptr(unsafe.Pointer(&s.origMode)))
-		mode := s.origMode
+		mode, _ := s.GetTerminalMode()
+		s.origMode = mode
 		mode.Iflag &^= icrnl | inpck | istrip | ixon
 		mode.Cflag |= cs8
 		mode.Lflag &^= syscall.ECHO | icanon | iexten
-		syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), setTermios, uintptr(unsafe.Pointer(&mode)))
+		s.SetTerminalMode(mode)
 
 		winch := make(chan os.Signal, 1)
 		signal.Notify(winch, syscall.SIGWINCH)
@@ -316,7 +315,27 @@ func (s *State) promptUnsupported(p string) (string, error) {
 func (s *State) Close() error {
 	stopSignal(s.winch)
 	if s.terminalSupported {
-		syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), setTermios, uintptr(unsafe.Pointer(&s.origMode)))
+		s.SetTerminalMode(s.origMode)
 	}
 	return nil
+}
+
+func (s *State) GetOriginalMode() (TerminalMode, bool) {
+	return s.origMode, TerminalSupported()
+}
+
+func (s *State) GetTerminalMode() (TerminalMode, bool) {
+	var mode TerminalMode
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), getTermios, uintptr(unsafe.Pointer(&mode)))
+	return mode, errno == 0
+}
+
+func (s *State) SetTerminalMode(mode TerminalMode) bool {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), setTermios, uintptr(unsafe.Pointer(&mode)))
+	return errno == 0
+}
+
+func TerminalSupported() bool {
+	bad := map[string]bool{"": true, "dumb": true, "cons25": true}
+	return !bad[strings.ToLower(os.Getenv("TERM"))]
 }

--- a/input_linux.go
+++ b/input_linux.go
@@ -20,6 +20,6 @@ const (
 	iexten = syscall.IEXTEN
 )
 
-type termios struct {
+type TerminalMode struct {
 	syscall.Termios
 }


### PR DESCRIPTION
Hi Peter,

I exposed the liner.termios type and renamed it TerminalMode. I added a TerminalSupported function and GetTerminalMode/SetTerminalMode methods. I also added a GetOriginalMode method.

GetTerminalMode returns a boolean status in addition to the TerminalMode. This is because it was being checked in input_windows.go. To maintain the current behavior the status is currently ignored in input.go. For symmetry, SetTerminalMode also returns a boolean status (currently it always returns true in input_windows.go). Again to maintain the current behavior the status is ignored in both input.go and input_windows.go.

Let me know what you think of these changes.

Thanks,

Michael.
