### PR TITLE
Printing Above Prompt

### DIFF
--- a/line.go
+++ b/line.go
@@ -73,11 +73,11 @@ var pos int = 0
 var prompt string
 
 // remembers if we are in tabComplete func or not (used for refreshing prompt)
-var tabbing bool = false 
+var tabbing bool = false
 
 // global vars for tabComplete
 var hl int
-var head, pick, tail string 
+var head, pick, tail string
 
 func (s *State) PrintAbovePrompt(str string) {
 	out := "\r" + str
@@ -86,11 +86,11 @@ func (s *State) PrintAbovePrompt(str string) {
 	}
 	fmt.Println(out)
 
-  if tabbing {
-    s.refresh(prompt, head+pick+tail, hl+utf8.RuneCountInString(pick))
-  } else {
-	  s.refresh(prompt, string(line), pos)
-  }
+	if tabbing {
+		s.refresh(prompt, head+pick+tail, hl+utf8.RuneCountInString(pick))
+	} else {
+		s.refresh(prompt, string(line), pos)
+	}
 }
 
 func (s *State) refresh(prompt string, buf string, pos int) error {
@@ -152,7 +152,7 @@ func (s *State) tabComplete(p string, line []rune, pos int) ([]rune, int, interf
 	if s.completer == nil {
 		return line, pos, rune(tab), nil
 	}
-  var list []string
+	var list []string
 	head, list, tail = s.completer(string(line), pos)
 	if len(list) <= 0 {
 		return line, pos, rune(tab), nil
@@ -222,9 +222,9 @@ mainLoop:
 		}
 
 		if key, ok := next.(rune); ok && key == tab {
-      tabbing = true
+			tabbing = true
 			line, pos, next, err = s.tabComplete(p, line, pos)
-      tabbing = false
+			tabbing = false
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Hi, I'm using your package to implement a CLI. While writing on the prompt line, I dump logs on the screen (using `fmt.Println`) and they overwrite the prompt, which is annoying to me.

So I tried to improve the package adding a `line.PrintAbovePrompt` func. Hope I didn't mess up the code. 
Let me know what you think and in case I'll try to correct.

Thanks
Luca

Here a working example (I'm importing `github.com/lucacervasio/liner` just because I forked your repo for the PR).

``` go
package main

import (
    "fmt"
    "github.com/lucacervasio/liner"
    "os"
    "os/signal"
    "strings"
    "time"
)

var line *liner.State = liner.NewLiner()

func main() {
    go logsDumper()
    defer line.Close()

    c := make(chan os.Signal, 1)
    signal.Notify(c, os.Interrupt)
    go func() {
        for sig := range c {
            // sig is a ^C, handle it
            if sig.String() == "interrupt" {
                fmt.Printf("\n")
                line.Close()
                os.Exit(0)
            }
        }
    }()

    baseCmds := []string{"exit", "help", "version", "list", "status", "shutdown", "uptime"}

    line.SetCompleter(func(line string) (c []string) {
        for _, n := range baseCmds {
            if strings.HasPrefix(n, strings.ToLower(line)) {
                c = append(c, n)
            }
        }
        return
    })

    for {

        if cmd, err := line.Prompt("Prompt> "); err != nil {
            fmt.Println("Error reading line: ", err)
        } else {
            if cmd != "" && cmd != "\n" && cmd != "\r\n" {
                line.AppendHistory(cmd)
                fmt.Println("Ei you said", cmd)
            }
        }

    }

}

func logsDumper() {
    for {
        line.PrintAbovePrompt("Hello")
        time.Sleep(2 * time.Second)
    }
}
```
