### PR TITLE
Emacs-like killRing

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,6 +7,7 @@ package liner
 
 import (
 	"bufio"
+	"container/ring"
 	"errors"
 	"fmt"
 	"io"
@@ -22,9 +23,13 @@ type commonState struct {
 	historyMutex      sync.RWMutex
 	completer         WordCompleter
 	columns           int
+	killRing          *ring.Ring
 }
 
 var errNotTerminalOutput = errors.New("standard output is not a terminal")
+
+// Max elements to save on the killring
+const KillRingMax = 60
 
 // HistoryLimit is the maximum number of entries saved in the scrollback history.
 const HistoryLimit = 1000

--- a/input.go
+++ b/input.go
@@ -307,6 +307,9 @@ func (s *State) readNext() (interface{}, error) {
 		default:
 			return unknown, nil
 		}
+	case 'y':
+		s.pending = s.pending[:0] // escape code complete
+		return altY, nil
 	default:
 		rv := s.pending[0]
 		s.pending = s.pending[1:]

--- a/input_windows.go
+++ b/input_windows.go
@@ -127,6 +127,7 @@ const (
 	vk_f10    = 0x79
 	vk_f11    = 0x7a
 	vk_f12    = 0x7b
+	yKey      = 0x59
 )
 
 const (
@@ -172,6 +173,9 @@ func (s *State) readNext() (interface{}, error) {
 
 		if ke.VirtualKeyCode == vk_tab && ke.ControlKeyState&modKeys == shiftPressed {
 			s.key = shiftTab
+		} else if ke.VirtualKeyCode == yKey && (ke.ControlKeyState&modKeys == leftAltPressed ||
+			ke.ControlKeyState&modKeys == rightAltPressed) {
+			s.key = altY
 		} else if ke.Char > 0 {
 			s.key = rune(ke.Char)
 		} else {


### PR DESCRIPTION
Small but very useful changes. Now, when you do ctrlK the part of the line that was "killed" or removed is added to a circular linked list, called the killRing. When ctrlY is pressed, the prompt enters killRing mode.

When entering killRing mode, the element pointed as current by the killRing is inserted to the line in the current position, then the system waits for one of twothings:
- altY is pressed: The current element indicator of the killRing moves to the previous element, and the function loops.
- Any other key is pressed: The function returns with next = the key that was pressed.

After the function returns, if the value for next is ctrlY then the functions starts again.
