### PR TITLE
Added tab prompter capability

### DIFF
--- a/common.go
+++ b/common.go
@@ -28,7 +28,24 @@ type commonState struct {
 	killRing          *ring.Ring
 	ctrlCAborts       bool
 	r                 *bufio.Reader
+	tabStyle          TabStyle
 }
+
+// TabStyle is used to select how tab completions are displayed.
+type TabStyle int
+
+// Two tab styles are currently available:
+//
+// TabCircular cycles through each completion item and displays it directly on
+// the prompt
+//
+// TabPrints prints the list of completion items to the screen after a second
+// tab key is pressed. This behaves similar to GNU readline and BASH (which
+// uses readline)
+const (
+	TabCircular TabStyle = iota
+	TabPrints
+)
 
 // ErrPromptAborted is returned from Prompt or PasswordPrompt when the user presses Ctrl-C
 // if SetCtrlCAborts(true) has been called on the State
@@ -165,6 +182,15 @@ func (s *State) SetCompleter(f Completer) {
 // fetch completion candidates when the user presses tab.
 func (s *State) SetWordCompleter(f WordCompleter) {
 	s.completer = f
+}
+
+// SetTabCompletionStyle sets the behvavior when the Tab key is pressed
+// for auto-completion.  TabCircular is the default behavior and cycles
+// through the list of candidates at the prompt.  TabPrints will print
+// the available completion candidates to the screen similar to BASH
+// and GNU Readline
+func (s *State) SetTabCompletionStyle(tabStyle TabStyle) {
+	s.tabStyle = tabStyle
 }
 
 // ModeApplier is the interface that wraps a representation of the terminal

--- a/line.go
+++ b/line.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -142,6 +143,29 @@ func (s *State) refresh(prompt []rune, buf []rune, pos int) error {
 	return err
 }
 
+func longestCommonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	longest := strs[0]
+
+	for _, str := range strs[1:] {
+		if str != longest {
+			nextLongest := ""
+			for i, _ := range str {
+				if strings.HasPrefix(longest, str[:i+1]) {
+					nextLongest = str[:i+1]
+				} else {
+					longest = str[:i+1]
+					break
+				}
+			}
+			longest = nextLongest
+		}
+	}
+	return longest
+}
+
 func (s *State) circularTabs(items []string) func(tabDirection) string {
 	item := -1
 	return func(direction tabDirection) string {
@@ -214,7 +238,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) string {
 		} else {
 			numTabs++
 		}
-		return ""
+		return longestCommonPrefix(items)
 	}
 }
 

--- a/line.go
+++ b/line.go
@@ -220,11 +220,16 @@ func (s *State) printedTabs(items []string) func(tabDirection) string {
 			}
 
 			numColumns := s.columns / maxWidth
+			numRows := len(items) / numColumns
+			if len(items)%numColumns > 0 {
+				numRows += 1
+			}
+
 			if len(items) <= numColumns {
 				maxWidth = 0
 			}
-			for i := 0; i < len(items); i += numColumns {
-				for j := 0; j < numColumns; j++ {
+			for i := 0; i < numRows; i++ {
+				for j := 0; j < numColumns*numRows; j += numRows {
 					if i+j < len(items) {
 						if maxWidth > 0 {
 							fmt.Printf("%-*s", maxWidth, items[i+j])


### PR DESCRIPTION
In an attempt to allow customization of the tab prompt (requested in #20) I've added a "tab prompter" callback to the tab completion.  This isn't yet documented or unit tested.  However, if this seems like a reasonable approach and would be accepted, then I'll add documentation and tests to the pull request.  An example of bash-like tab prompting would be:

``` Go
func(items []string, readNext liner.NextReader) (string, error) {
  if len(items) == 0 {
    return "", nil
  } else if len(items) == 1 {
    return items[0], nil
  } else if len(items) > completionQueryItems {
    fmt.Printf("\nDisplay all %d possibilities? (y or n) ", len(items))
    for {
      next, err := readNext()
      if err != nil {
        return "", err
      }

      if key, ok := next.(rune); ok {
        if unicode.ToLower(key) == 'n' {
          return "", nil
        } else if unicode.ToLower(key) == 'y' {
          break
        }
      }
    }
  }

  fmt.Printf("\n%v\n", items)
  return "", nil
}
```

The above example would present a very basic display of the possibilities when a single tab is pressed.  While not exactly like bash (no tab-tab support) it certainly allows for customizing the prompt.  Please let me know what you think.

Regards,
Andrew