### PR TITLE
Fall out of tabComplete when only a single completion candidate exists

### DIFF
--- a/line.go
+++ b/line.go
@@ -257,6 +257,11 @@ func (s *State) tabComplete(p []rune, line []rune, pos int) ([]rune, int, interf
 		return line, pos, rune(esc), nil
 	}
 	hl := utf8.RuneCountInString(head)
+	if len(list) == 1 {
+		s.refresh(p, []rune(head+list[0]+tail), hl+utf8.RuneCountInString(list[0]))
+		return []rune(head + list[0] + tail), hl + utf8.RuneCountInString(list[0]), rune(esc), nil
+	}
+
 	direction := tabForward
 	tabPrinter := s.circularTabs(list)
 	if s.tabStyle == TabPrints {


### PR DESCRIPTION
This change implements tabCompletion for a single candidate as discussed in #36.

If the completer function returns a slice with a single completion candidate in it, then update the prompt with that candidate and return control back to the read loop.  It doesn't make sense to go into tab completion for a single item