### PR TITLE
Add support for double-width (CJK) characters

### DIFF
--- a/width.go
+++ b/width.go
@@ -13,10 +13,23 @@ var zeroWidth = []*unicode.RangeTable{
 	unicode.Cf,
 }
 
+var doubleWidth = []*unicode.RangeTable{
+	unicode.Han,
+	unicode.Hangul,
+	unicode.Hiragana,
+	unicode.Katakana,
+}
+
+// countGlyphs considers zero-width characters to be zero glyphs wide,
+// and members of Chinese, Japanese, and Korean scripts to be 2 glyphs wide.
 func countGlyphs(s []rune) int {
 	n := 0
 	for _, r := range s {
-		if !unicode.IsOneOf(zeroWidth, r) {
+		switch {
+		case unicode.IsOneOf(zeroWidth, r):
+		case unicode.IsOneOf(doubleWidth, r):
+			n += 2
+		default:
 			n++
 		}
 	}

--- a/width_test.go
+++ b/width_test.go
@@ -14,16 +14,27 @@ func accent(in []rune) []rune {
 	return out
 }
 
-var testString = []rune("query")
+type testCase struct {
+	s      []rune
+	glyphs int
+}
+
+var testCases = []testCase{
+	{[]rune("query"), 5},
+	{[]rune("私"), 2},
+	{[]rune("hello世界"), 9},
+}
 
 func TestCountGlyphs(t *testing.T) {
-	count := countGlyphs(testString)
-	if count != len(testString) {
-		t.Errorf("ASCII count incorrect. %d != %d", count, len(testString))
-	}
-	count = countGlyphs(accent(testString))
-	if count != len(testString) {
-		t.Errorf("Accent count incorrect. %d != %d", count, len(testString))
+	for _, testCase := range testCases {
+		count := countGlyphs(testCase.s)
+		if count != testCase.glyphs {
+			t.Errorf("ASCII count incorrect. %d != %d", count, testCase.glyphs)
+		}
+		count = countGlyphs(accent(testCase.s))
+		if count != testCase.glyphs {
+			t.Errorf("Accent count incorrect. %d != %d", count, testCase.glyphs)
+		}
 	}
 }
 
@@ -41,47 +52,51 @@ func compare(a, b []rune, name string, t *testing.T) {
 }
 
 func TestPrefixGlyphs(t *testing.T) {
-	for i := 0; i <= len(testString); i++ {
-		iter := strconv.Itoa(i)
-		out := getPrefixGlyphs(testString, i)
-		compare(out, testString[:i], "ascii prefix "+iter, t)
-		out = getPrefixGlyphs(accent(testString), i)
-		compare(out, accent(testString[:i]), "accent prefix "+iter, t)
-	}
-	out := getPrefixGlyphs(testString, 999)
-	compare(out, testString, "ascii prefix overflow", t)
-	out = getPrefixGlyphs(accent(testString), 999)
-	compare(out, accent(testString), "accent prefix overflow", t)
+	for _, testCase := range testCases {
+		for i := 0; i <= len(testCase.s); i++ {
+			iter := strconv.Itoa(i)
+			out := getPrefixGlyphs(testCase.s, i)
+			compare(out, testCase.s[:i], "ascii prefix "+iter, t)
+			out = getPrefixGlyphs(accent(testCase.s), i)
+			compare(out, accent(testCase.s[:i]), "accent prefix "+iter, t)
+		}
+		out := getPrefixGlyphs(testCase.s, 999)
+		compare(out, testCase.s, "ascii prefix overflow", t)
+		out = getPrefixGlyphs(accent(testCase.s), 999)
+		compare(out, accent(testCase.s), "accent prefix overflow", t)
 
-	out = getPrefixGlyphs(testString, -3)
-	if len(out) != 0 {
-		t.Error("ascii prefix negative")
-	}
-	out = getPrefixGlyphs(accent(testString), -3)
-	if len(out) != 0 {
-		t.Error("accent prefix negative")
+		out = getPrefixGlyphs(testCase.s, -3)
+		if len(out) != 0 {
+			t.Error("ascii prefix negative")
+		}
+		out = getPrefixGlyphs(accent(testCase.s), -3)
+		if len(out) != 0 {
+			t.Error("accent prefix negative")
+		}
 	}
 }
 
 func TestSuffixGlyphs(t *testing.T) {
-	for i := 0; i <= len(testString); i++ {
-		iter := strconv.Itoa(i)
-		out := getSuffixGlyphs(testString, i)
-		compare(out, testString[len(testString)-i:], "ascii suffix "+iter, t)
-		out = getSuffixGlyphs(accent(testString), i)
-		compare(out, accent(testString[len(testString)-i:]), "accent suffix "+iter, t)
-	}
-	out := getSuffixGlyphs(testString, 999)
-	compare(out, testString, "ascii suffix overflow", t)
-	out = getSuffixGlyphs(accent(testString), 999)
-	compare(out, accent(testString), "accent suffix overflow", t)
+	for _, testCase := range testCases {
+		for i := 0; i <= len(testCase.s); i++ {
+			iter := strconv.Itoa(i)
+			out := getSuffixGlyphs(testCase.s, i)
+			compare(out, testCase.s[len(testCase.s)-i:], "ascii suffix "+iter, t)
+			out = getSuffixGlyphs(accent(testCase.s), i)
+			compare(out, accent(testCase.s[len(testCase.s)-i:]), "accent suffix "+iter, t)
+		}
+		out := getSuffixGlyphs(testCase.s, 999)
+		compare(out, testCase.s, "ascii suffix overflow", t)
+		out = getSuffixGlyphs(accent(testCase.s), 999)
+		compare(out, accent(testCase.s), "accent suffix overflow", t)
 
-	out = getSuffixGlyphs(testString, -3)
-	if len(out) != 0 {
-		t.Error("ascii suffix negative")
-	}
-	out = getSuffixGlyphs(accent(testString), -3)
-	if len(out) != 0 {
-		t.Error("accent suffix negative")
+		out = getSuffixGlyphs(testCase.s, -3)
+		if len(out) != 0 {
+			t.Error("ascii suffix negative")
+		}
+		out = getSuffixGlyphs(accent(testCase.s), -3)
+		if len(out) != 0 {
+			t.Error("accent suffix negative")
+		}
 	}
 }


### PR DESCRIPTION
Tested on OS X and the latest Ubuntu, using the default terminal application for each, and from a tty on Ubuntu. 

Sorry for all the diff noise in width_test.go. The actual test semantics only change in TestCountGlyphs, which compares against the pre-computed testCase.glyphs rather than the length of a slice of runes.

Fixes #42