### PR TITLE
Stop word movement plodding in consecutive whitespace

### DIFF
--- a/line.go
+++ b/line.go
@@ -739,9 +739,19 @@ mainLoop:
 				}
 			case wordRight:
 				if pos < len(line) {
+					var spaceHere, spaceLeft, hereKnown bool
 					for {
 						pos++
-						if pos == len(line) || unicode.IsSpace(line[pos]) {
+						if pos == len(line) {
+							break
+						}
+						if hereKnown {
+							spaceLeft = spaceHere
+						} else {
+							spaceLeft = unicode.IsSpace(line[pos-1])
+						}
+						spaceHere, hereKnown = unicode.IsSpace(line[pos]), true
+						if spaceHere && !spaceLeft {
 							break
 						}
 					}

--- a/line.go
+++ b/line.go
@@ -712,9 +712,19 @@ mainLoop:
 				}
 			case wordLeft:
 				if pos > 0 {
+					var spaceHere, spaceLeft, leftKnown bool
 					for {
 						pos--
-						if pos == 0 || unicode.IsSpace(line[pos-1]) {
+						if pos == 0 {
+							break
+						}
+						if leftKnown {
+							spaceHere = spaceLeft
+						} else {
+							spaceHere = unicode.IsSpace(line[pos])
+						}
+						spaceLeft, leftKnown = unicode.IsSpace(line[pos-1]), true
+						if !spaceHere && spaceLeft {
 							break
 						}
 					}


### PR DESCRIPTION
Say the line being edited is:

    Pos:    0123456789
    Rune:   ab   c  d 

At the moment, if the cursor is at position 5, it takes three wordLefts to move to position 0. I'd expect one.

Similarly, if the cursor is at position 6, it takes two wordRights to move to position 9. I'd expect one.

This patch checks that not only whitespace but non-whitespace too must be present for a position to be considered a word boundary. Let me know what you think.
