### PR TITLE
Allow for better usability in word-based cursor movement and deletion

### DIFF
--- a/common.go
+++ b/common.go
@@ -29,6 +29,7 @@ type commonState struct {
 	ctrlCAborts       bool
 	r                 *bufio.Reader
 	tabStyle          TabStyle
+	wordBreakers      []rune
 }
 
 // TabStyle is used to select how tab completions are displayed.
@@ -205,6 +206,21 @@ type ModeApplier interface {
 // (and Prompt does not return) regardless of the value passed to SetCtrlCAborts.
 func (s *State) SetCtrlCAborts(aborts bool) {
 	s.ctrlCAborts = aborts
+}
+
+// SetWordBreakers sets runes that will be considered stops for word-based
+// cursor movement and deletion without requiring surrounding whitespace.
+func (s *State) SetWordBreakers(breakers ...rune) {
+	s.wordBreakers = breakers
+}
+
+func (s *State) wordBreaker(r rune) bool {
+	for _, br := range s.wordBreakers {
+		if r == br {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *State) promptUnsupported(p string) (string, error) {

--- a/line.go
+++ b/line.go
@@ -712,18 +712,20 @@ mainLoop:
 				}
 			case wordLeft:
 				if pos > 0 {
-					var spaceHere, spaceLeft, leftKnown bool
+					var spaceLeft, spaceHere, havePrevIter bool
 					for {
 						pos--
 						if pos == 0 {
 							break
 						}
-						if leftKnown {
+						left, here := line[pos-1], line[pos]
+						if havePrevIter {
 							spaceHere = spaceLeft
 						} else {
-							spaceHere = unicode.IsSpace(line[pos])
+							spaceHere = unicode.IsSpace(here)
 						}
-						spaceLeft, leftKnown = unicode.IsSpace(line[pos-1]), true
+						spaceLeft = unicode.IsSpace(left)
+						havePrevIter = true
 						if !spaceHere && spaceLeft {
 							break
 						}
@@ -739,18 +741,20 @@ mainLoop:
 				}
 			case wordRight:
 				if pos < len(line) {
-					var spaceHere, spaceLeft, hereKnown bool
+					var spaceLeft, spaceHere, havePrevIter bool
 					for {
 						pos++
 						if pos == len(line) {
 							break
 						}
-						if hereKnown {
+						left, here := line[pos-1], line[pos]
+						if havePrevIter {
 							spaceLeft = spaceHere
 						} else {
-							spaceLeft = unicode.IsSpace(line[pos-1])
+							spaceLeft = unicode.IsSpace(left)
 						}
-						spaceHere, hereKnown = unicode.IsSpace(line[pos]), true
+						spaceHere = unicode.IsSpace(here)
+						havePrevIter = true
 						if spaceHere && !spaceLeft {
 							break
 						}

--- a/line.go
+++ b/line.go
@@ -726,7 +726,9 @@ mainLoop:
 						}
 						spaceLeft = unicode.IsSpace(left)
 						havePrevIter = true
-						if !spaceHere && spaceLeft {
+						if s.wordBreaker(here) ||
+							(spaceLeft || s.wordBreaker(left)) && !spaceHere {
+							// Word begins here.
 							break
 						}
 					}
@@ -755,7 +757,9 @@ mainLoop:
 						}
 						spaceHere = unicode.IsSpace(here)
 						havePrevIter = true
-						if spaceHere && !spaceLeft {
+						if s.wordBreaker(left) ||
+							!spaceLeft && (spaceHere || s.wordBreaker(here)) {
+							// Word ends here.
 							break
 						}
 					}

--- a/line.go
+++ b/line.go
@@ -643,12 +643,25 @@ mainLoop:
 					line = append(line[:pos-1], line[pos:]...)
 					pos--
 				}
-				// Remove non-whitespace to the left
+				posPriorToWordRemoval := pos
+				// Remove a word to the left
+				var breakerEncountered bool
 				for {
-					if pos == 0 || unicode.IsSpace(line[pos-1]) {
+					if pos == 0 {
 						break
 					}
-					buf = append(buf, line[pos-1])
+					left := line[pos-1]
+					if unicode.IsSpace(left) || breakerEncountered {
+						break
+					}
+					if s.wordBreaker(left) {
+						// ctrlW should remove at least one non-whitespace rune
+						if pos != posPriorToWordRemoval {
+							break
+						}
+						breakerEncountered = true
+					}
+					buf = append(buf, left)
 					line = append(line[:pos-1], line[pos:]...)
 					pos--
 				}


### PR DESCRIPTION
Hi again. More word stuff.

The standard `unicode.IsSpace` based word boundaries seem fine for most usages, but when for example using liner as a language REPL, it'd be nice to be able to tweak what constitutes a word for cursor movement and deletion purposes.

This patch adds the method:

    // SetWordBreakers sets runes that will be considered stops for word-based
    // cursor movement and deletion without requiring surrounding whitespace.
    func (s *State) SetWordBreakers(breakers ...rune) 

And updates `wordLeft`, `wordRight` and `ctrlW` accordingly. 

It's best to just try those 3 actions in some examples with and without the patch to get a feel for the difference. e.g.

```go
ed.SetWordBreakers('(', ')')
// and editing the line: 
// (def zip (proc (xs ys) (zip-with cons xs ys)))
```

and

```go
ed.SetWordBreakers('.', '/')
// and editing the line: 
// https://github.com/peterh/liner
```

What do you think? This gives the means for a good boost in usability when liner is used for language REPLs, without complicating the implementation much.
