### PR TITLE
fix completer

### DIFF
--- a/common.go
+++ b/common.go
@@ -177,7 +177,7 @@ func (s *State) SetCompleter(f Completer) {
 		return
 	}
 	s.completer = func(line string, pos int) (string, []string, string) {
-		return "", f(line[:pos]), line[pos:]
+		return "", f(string([]rune(line)[:pos])), string([]rune(line)[pos:])
 	}
 }
 


### PR DESCRIPTION
suffix of completion break utf-8 bytes when the line is ended with utf-8 multi-byte.
