### PR TITLE
Fix the output redirect check when the number of columns reported is zero

### DIFF
--- a/input.go
+++ b/input.go
@@ -67,8 +67,7 @@ func NewLiner() *State {
 	}
 
 	if !s.outputRedirected {
-		s.getColumns()
-		s.outputRedirected = s.columns <= 0
+		s.outputRedirected = !s.getColumns()
 	}
 
 	return &s

--- a/output.go
+++ b/output.go
@@ -48,14 +48,15 @@ type winSize struct {
 	xpixel, ypixel uint16
 }
 
-func (s *State) getColumns() {
+func (s *State) getColumns() bool {
 	var ws winSize
 	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdout),
 		syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws)))
-	if ok < 0 {
-		s.columns = 80
+	if int(ok) < 0 {
+		return false
 	}
 	s.columns = int(ws.col)
+	return true
 }
 
 func (s *State) checkOutput() {


### PR DESCRIPTION
Inside of Docker the output terminal will sometimes report a terminal
with zero columns when attempting to get terminal info for standard out
and then will resize the terminal triggering a SIGWINCH.  The return
value check was incorrect as it never casted the return value and the
if statement functionally didn't do anything even if it was correct.

As the intention is to determine if the terminal is a TTY, this function
now returns a boolean that indicates if the `ioctl()` call succeeded or
not rather than checking the number of columns to see if the output is a
terminal (as it can be zero and resized).