### PR TITLE
speed up input

### DIFF
--- a/common.go
+++ b/common.go
@@ -27,6 +27,7 @@ type commonState struct {
 	killRing          *ring.Ring
 	ctrlCAborts       bool
 	r                 *bufio.Reader
+	w                 io.Writer
 	tabStyle          TabStyle
 	multiLineMode     bool
 	cursorRows        int
@@ -227,7 +228,7 @@ func (s *State) SetShouldRestart(f ShouldRestart) {
 
 func (s *State) promptUnsupported(p string) (string, error) {
 	if !s.inputRedirected || !s.terminalSupported {
-		fmt.Print(p)
+		fmt.Fprint(s.w, p)
 	}
 	linebuf, _, err := s.r.ReadLine()
 	if err != nil {

--- a/input.go
+++ b/input.go
@@ -5,6 +5,7 @@ package liner
 import (
 	"bufio"
 	"errors"
+	"io"
 	"os"
 	"os/signal"
 	"strconv"
@@ -37,16 +38,28 @@ type State struct {
 // upgrade to a newer release of Go, or ensure that NewLiner is only called
 // once.
 func NewLiner() *State {
+	return newLiner(os.Stdin, os.Stdout, syscall.Stdin, syscall.Stdout)
+}
+
+func newLiner(r io.Reader, w io.Writer, inFD int, outFD int) *State {
 	var s State
-	s.r = bufio.NewReader(os.Stdin)
+	s.r = bufio.NewReader(r)
+	s.w = w
 
 	s.terminalSupported = TerminalSupported()
-	if m, err := TerminalMode(); err == nil {
+
+	// ensure that the user specified file descriptors get used in all cases
+	s.origMode.InputFD = inFD
+	s.origMode.OutputFD = outFD
+	s.defaultMode.InputFD = inFD
+	s.defaultMode.OutputFD = outFD
+
+	if m, err := terminalMode(inFD, outFD); err == nil {
 		s.origMode = *m.(*termios)
 	} else {
 		s.inputRedirected = true
 	}
-	if _, err := getMode(syscall.Stdout); err != 0 {
+	if _, err := getMode(inFD, outFD); err != 0 {
 		s.outputRedirected = true
 	}
 	if s.inputRedirected && s.outputRedirected {
@@ -77,7 +90,7 @@ var errTimedOut = errors.New("timeout")
 
 func (s *State) startPrompt() {
 	if s.terminalSupported {
-		if m, err := TerminalMode(); err == nil {
+		if m, err := terminalMode(s.origMode.InputFD, s.origMode.OutputFD); err == nil {
 			s.defaultMode = *m.(*termios)
 			mode := s.defaultMode
 			mode.Lflag &^= isig

--- a/input_darwin.go
+++ b/input_darwin.go
@@ -29,13 +29,15 @@ const (
 )
 
 type termios struct {
-	Iflag  uintptr
-	Oflag  uintptr
-	Cflag  uintptr
-	Lflag  uintptr
-	Cc     [20]byte
-	Ispeed uintptr
-	Ospeed uintptr
+	Iflag    uintptr
+	Oflag    uintptr
+	Cflag    uintptr
+	Lflag    uintptr
+	Cc       [20]byte
+	Ispeed   uintptr
+	Ospeed   uintptr
+	InputFD  int
+	OutputFD int
 }
 
 // Terminal.app needs a column for the cursor when the input line is at the

--- a/input_linux.go
+++ b/input_linux.go
@@ -23,6 +23,8 @@ const (
 
 type termios struct {
 	syscall.Termios
+	InputFD  int
+	OutputFD int
 }
 
 const cursorColumn = false

--- a/line.go
+++ b/line.go
@@ -99,7 +99,7 @@ func (s *State) refresh(prompt []rune, buf []rune, pos int) error {
 
 func (s *State) refreshSingleLine(prompt []rune, buf []rune, pos int) error {
 	s.cursorPos(0)
-	_, err := fmt.Print(string(prompt))
+	_, err := fmt.Fprint(s.w, string(prompt))
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (s *State) refreshSingleLine(prompt []rune, buf []rune, pos int) error {
 	bLen := countGlyphs(buf)
 	pos = countGlyphs(buf[:pos])
 	if pLen+bLen < s.columns {
-		_, err = fmt.Print(string(buf))
+		_, err = fmt.Fprint(s.w, string(buf))
 		s.eraseLine()
 		s.cursorPos(pLen + pos)
 	} else {
@@ -139,11 +139,11 @@ func (s *State) refreshSingleLine(prompt []rune, buf []rune, pos int) error {
 
 		// Output
 		if start > 0 {
-			fmt.Print("{")
+			fmt.Fprint(s.w, "{")
 		}
-		fmt.Print(string(line))
+		fmt.Fprint(s.w, string(line))
 		if end < bLen {
-			fmt.Print("}")
+			fmt.Fprint(s.w, "}")
 		}
 
 		// Set cursor position
@@ -184,10 +184,10 @@ func (s *State) refreshMultiLine(prompt []rune, buf []rune, pos int) error {
 	s.eraseLine()
 
 	/* Write the prompt and the current buffer content */
-	if _, err := fmt.Print(string(prompt)); err != nil {
+	if _, err := fmt.Fprint(s.w, string(prompt)); err != nil {
 		return err
 	}
-	if _, err := fmt.Print(string(buf)); err != nil {
+	if _, err := fmt.Fprint(s.w, string(buf)); err != nil {
 		return err
 	}
 
@@ -222,7 +222,7 @@ func (s *State) resetMultiLine(prompt []rune, buf []rune, pos int) {
 	cursorRows := (columns + s.columns) / s.columns
 	if s.maxRows-cursorRows > 0 {
 		for i := 0; i < s.maxRows-cursorRows; i++ {
-			fmt.Println() // always moves the cursor down or scrolls the window up as needed
+			fmt.Fprintln(s.w) // always moves the cursor down or scrolls the window up as needed
 		}
 	}
 	s.maxRows = 1
@@ -298,7 +298,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 
 		if numTabs == 2 {
 			if len(items) > 100 {
-				fmt.Printf("\nDisplay all %d possibilities? (y or n) ", len(items))
+				fmt.Fprintf(s.w, "\nDisplay all %d possibilities? (y or n) ", len(items))
 			prompt:
 				for {
 					next, err := s.readNext()
@@ -318,7 +318,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 					}
 				}
 			}
-			fmt.Println("")
+			fmt.Fprintln(s.w, "")
 
 			numColumns, numRows, maxWidth := calculateColumns(s.columns, items)
 
@@ -326,13 +326,13 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 				for j := 0; j < numColumns*numRows; j += numRows {
 					if i+j < len(items) {
 						if maxWidth > 0 {
-							fmt.Printf("%-*.[1]*s", maxWidth, items[i+j])
+							fmt.Fprintf(s.w, "%-*.[1]*s", maxWidth, items[i+j])
 						} else {
-							fmt.Printf("%v ", items[i+j])
+							fmt.Fprintf(s.w, "%v ", items[i+j])
 						}
 					}
 				}
-				fmt.Println("")
+				fmt.Fprintln(s.w, "")
 			}
 		} else {
 			numTabs++
@@ -425,7 +425,7 @@ func (s *State) reverseISearch(origLine []rune, origPos int) ([]rune, int, inter
 					foundLine = history[historyPos]
 					foundPos = positions[historyPos]
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlS: // Search forward
 				if historyPos < len(history)-1 && historyPos >= 0 {
@@ -433,11 +433,11 @@ func (s *State) reverseISearch(origLine []rune, origPos int) ([]rune, int, inter
 					foundLine = history[historyPos]
 					foundPos = positions[historyPos]
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlH, bs: // Backspace
 				if pos <= 0 {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					n := len(getSuffixGlyphs(line[:pos], 1))
 					line = append(line[:pos-n], line[pos:]...)
@@ -583,7 +583,7 @@ func (s *State) PromptWithSuggestion(prompt string, text string, pos int) (strin
 	s.historyMutex.RLock()
 	defer s.historyMutex.RUnlock()
 
-	fmt.Print(prompt)
+	fmt.Fprint(s.w, prompt)
 	p := []rune(prompt)
 	var line = []rune(text)
 	historyEnd := ""
@@ -624,7 +624,7 @@ mainLoop:
 				if s.multiLineMode {
 					s.resetMultiLine(p, line, pos)
 				}
-				fmt.Println()
+				fmt.Fprintln(s.w)
 				break mainLoop
 			case ctrlA: // Start of line
 				pos = 0
@@ -637,14 +637,14 @@ mainLoop:
 					pos -= len(getSuffixGlyphs(line[:pos], 1))
 					s.refresh(p, line, pos)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlF: // right
 				if pos < len(line) {
 					pos += len(getPrefixGlyphs(line[pos:], 1))
 					s.refresh(p, line, pos)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlD: // del
 				if pos == 0 && len(line) == 0 {
@@ -657,7 +657,7 @@ mainLoop:
 				s.restartPrompt()
 
 				if pos >= len(line) {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					n := len(getPrefixGlyphs(line[pos:], 1))
 					line = append(line[:pos], line[pos+n:]...)
@@ -665,7 +665,7 @@ mainLoop:
 				}
 			case ctrlK: // delete remainder of line
 				if pos >= len(line) {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					if killAction > 0 {
 						s.addToKillRing(line[pos:], 1) // Add in apend mode
@@ -688,7 +688,7 @@ mainLoop:
 					pos = len(line)
 					s.refresh(p, line, pos)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlN: // down
 				historyAction = true
@@ -702,11 +702,11 @@ mainLoop:
 					pos = len(line)
 					s.refresh(p, line, pos)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case ctrlT: // transpose prev glyph with glyph under cursor
 				if len(line) < 2 || pos < 1 {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					if pos == len(line) {
 						pos -= len(getSuffixGlyphs(line, 1))
@@ -724,7 +724,7 @@ mainLoop:
 				s.eraseScreen()
 				s.refresh(p, line, pos)
 			case ctrlC: // reset
-				fmt.Println("^C")
+				fmt.Fprintln(s.w, "^C")
 				if s.multiLineMode {
 					s.resetMultiLine(p, line, pos)
 				}
@@ -733,11 +733,11 @@ mainLoop:
 				}
 				line = line[:0]
 				pos = 0
-				fmt.Print(prompt)
+				fmt.Fprint(s.w, prompt)
 				s.restartPrompt()
 			case ctrlH, bs: // Backspace
 				if pos <= 0 {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					n := len(getSuffixGlyphs(line[:pos], 1))
 					line = append(line[:pos-n], line[pos:]...)
@@ -757,7 +757,7 @@ mainLoop:
 				s.refresh(p, line, pos)
 			case ctrlW: // Erase word
 				if pos == 0 {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 					break
 				}
 				// Remove whitespace to the left
@@ -810,11 +810,11 @@ mainLoop:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:
-				fmt.Print(beep)
+				fmt.Fprint(s.w, beep)
 			default:
 				if pos == len(line) && !s.multiLineMode && countGlyphs(p)+countGlyphs(line) < s.columns-1 {
 					line = append(line, v)
-					fmt.Printf("%c", v)
+					fmt.Fprintf(s.w, "%c", v)
 					pos++
 				} else {
 					line = append(line[:pos], append([]rune{v}, line[pos:]...)...)
@@ -826,7 +826,7 @@ mainLoop:
 			switch v {
 			case del:
 				if pos >= len(line) {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					n := len(getPrefixGlyphs(line[pos:], 1))
 					line = append(line[:pos], line[pos+n:]...)
@@ -835,7 +835,7 @@ mainLoop:
 				if pos > 0 {
 					pos -= len(getSuffixGlyphs(line[:pos], 1))
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case wordLeft, altB:
 				if pos > 0 {
@@ -856,13 +856,13 @@ mainLoop:
 						}
 					}
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case right:
 				if pos < len(line) {
 					pos += len(getPrefixGlyphs(line[pos:], 1))
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case wordRight, altF:
 				if pos < len(line) {
@@ -883,7 +883,7 @@ mainLoop:
 						}
 					}
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case up:
 				historyAction = true
@@ -895,7 +895,7 @@ mainLoop:
 					line = []rune(prefixHistory[historyPos])
 					pos = len(line)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case down:
 				historyAction = true
@@ -908,7 +908,7 @@ mainLoop:
 					}
 					pos = len(line)
 				} else {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				}
 			case home: // Start of line
 				pos = 0
@@ -960,7 +960,7 @@ restart:
 	s.startPrompt()
 	s.getColumns()
 
-	fmt.Print(prompt)
+	fmt.Fprint(s.w, prompt)
 	p := []rune(prompt)
 	var line []rune
 	pos := 0
@@ -982,7 +982,7 @@ mainLoop:
 				if s.multiLineMode {
 					s.resetMultiLine(p, line, pos)
 				}
-				fmt.Println()
+				fmt.Fprintln(s.w)
 				break mainLoop
 			case ctrlD: // del
 				if pos == 0 && len(line) == 0 {
@@ -998,14 +998,14 @@ mainLoop:
 				s.refresh(p, []rune{}, 0)
 			case ctrlH, bs: // Backspace
 				if pos <= 0 {
-					fmt.Print(beep)
+					fmt.Fprint(s.w, beep)
 				} else {
 					n := len(getSuffixGlyphs(line[:pos], 1))
 					line = append(line[:pos-n], line[pos:]...)
 					pos -= n
 				}
 			case ctrlC:
-				fmt.Println("^C")
+				fmt.Fprintln(s.w, "^C")
 				if s.multiLineMode {
 					s.resetMultiLine(p, line, pos)
 				}
@@ -1014,7 +1014,7 @@ mainLoop:
 				}
 				line = line[:0]
 				pos = 0
-				fmt.Print(prompt)
+				fmt.Fprint(s.w, prompt)
 				s.restartPrompt()
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,
@@ -1022,7 +1022,7 @@ mainLoop:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:
-				fmt.Print(beep)
+				fmt.Fprint(s.w, beep)
 			default:
 				line = append(line[:pos], append([]rune{v}, line[pos:]...)...)
 				pos++

--- a/line_test.go
+++ b/line_test.go
@@ -3,6 +3,8 @@ package liner
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -134,4 +136,49 @@ func ExampleState_WriteHistory() {
 	// Output:
 	// History entry 0 : foo
 	// History entry 1 : bar
+}
+
+func BenchmarkInput1(b *testing.B)    { benchWithInput(b, 1) }
+func BenchmarkInput10(b *testing.B)   { benchWithInput(b, 10) }
+func BenchmarkInput100(b *testing.B)  { benchWithInput(b, 100) }
+func BenchmarkInput1000(b *testing.B) { benchWithInput(b, 1000) }
+
+func benchWithInput(b *testing.B, lineLength int) {
+	inpR, inpW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	s := newLiner(inpR, outW, -1, -1)
+	s.inputRedirected = false
+	s.outputRedirected = false
+	s.terminalSupported = true
+
+	go func() {
+		// discard any output from the prompt reader
+		io.Copy(ioutil.Discard, outR)
+	}()
+
+	buf := bytes.Buffer{}
+	for i := 0; i < lineLength; i++ {
+		buf.WriteByte('A')
+	}
+	buf.WriteByte('\n')
+	go func() {
+		for i := 0; i < b.N; i++ {
+			inpW.Write(buf.Bytes())
+		}
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		line, err := s.Prompt("test")
+		if err != nil {
+			b.Errorf("expected no errrors, got %s", err)
+		}
+		if len(line) != lineLength {
+			b.Errorf("expected to read %d bytes, got %d", b.N, len(line))
+		}
+	}
+	b.StopTimer()
+	inpW.Close()
+	outW.Close()
 }

--- a/output.go
+++ b/output.go
@@ -13,34 +13,34 @@ import (
 func (s *State) cursorPos(x int) {
 	if s.useCHA {
 		// 'G' is "Cursor Character Absolute (CHA)"
-		fmt.Printf("\x1b[%dG", x+1)
+		fmt.Fprintf(s.w, "\x1b[%dG", x+1)
 	} else {
 		// 'C' is "Cursor Forward (CUF)"
-		fmt.Print("\r")
+		fmt.Fprint(s.w, "\r")
 		if x > 0 {
-			fmt.Printf("\x1b[%dC", x)
+			fmt.Fprintf(s.w, "\x1b[%dC", x)
 		}
 	}
 }
 
 func (s *State) eraseLine() {
-	fmt.Print("\x1b[0K")
+	fmt.Fprint(s.w, "\x1b[0K")
 }
 
 func (s *State) eraseScreen() {
-	fmt.Print("\x1b[H\x1b[2J")
+	fmt.Fprint(s.w, "\x1b[H\x1b[2J")
 }
 
 func (s *State) moveUp(lines int) {
-	fmt.Printf("\x1b[%dA", lines)
+	fmt.Fprintf(s.w, "\x1b[%dA", lines)
 }
 
 func (s *State) moveDown(lines int) {
-	fmt.Printf("\x1b[%dB", lines)
+	fmt.Fprintf(s.w, "\x1b[%dB", lines)
 }
 
 func (s *State) emitNewLine() {
-	fmt.Print("\n")
+	fmt.Fprint(s.w, "\n")
 }
 
 type winSize struct {
@@ -50,7 +50,7 @@ type winSize struct {
 
 func (s *State) getColumns() bool {
 	var ws winSize
-	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdout),
+	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s.origMode.OutputFD),
 		syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws)))
 	if int(ok) < 0 {
 		return false

--- a/width.go
+++ b/width.go
@@ -25,6 +25,12 @@ var doubleWidth = []*unicode.RangeTable{
 func countGlyphs(s []rune) int {
 	n := 0
 	for _, r := range s {
+		// speed up the common case
+		if r < 127 {
+			n++
+			continue
+		}
+
 		switch {
 		case unicode.IsOneOf(zeroWidth, r):
 		case unicode.IsOneOf(doubleWidth, r):
@@ -39,6 +45,10 @@ func countGlyphs(s []rune) int {
 func countMultiLineGlyphs(s []rune, columns int, start int) int {
 	n := start
 	for _, r := range s {
+		if r < 127 {
+			n++
+			continue
+		}
 		switch {
 		case unicode.IsOneOf(zeroWidth, r):
 		case unicode.IsOneOf(doubleWidth, r):
@@ -58,6 +68,11 @@ func countMultiLineGlyphs(s []rune, columns int, start int) int {
 func getPrefixGlyphs(s []rune, num int) []rune {
 	p := 0
 	for n := 0; n < num && p < len(s); p++ {
+		// speed up the common case
+		if s[p] < 127 {
+			n++
+			continue
+		}
 		if !unicode.IsOneOf(zeroWidth, s[p]) {
 			n++
 		}
@@ -71,6 +86,11 @@ func getPrefixGlyphs(s []rune, num int) []rune {
 func getSuffixGlyphs(s []rune, num int) []rune {
 	p := len(s)
 	for n := 0; n < num && p > 0; p-- {
+		// speed up the common case
+		if s[p-1] < 127 {
+			n++
+			continue
+		}
 		if !unicode.IsOneOf(zeroWidth, s[p-1]) {
 			n++
 		}


### PR DESCRIPTION
There are two changes, one to enable some benchmarking and a second that speeds up counting glyphs.  

I kept them separate as you may just want the second change without all of the kludging to allow tests to trick the library into thinking it's talking to a terminal instead of a pipe.
