### PR TITLE
add function to clear history

### DIFF
--- a/common.go
+++ b/common.go
@@ -133,6 +133,13 @@ func (s *State) AppendHistory(item string) {
 	}
 }
 
+// ClearHistory clears the scroollback history.
+func (s *State) ClearHistory() {
+	s.historyMutex.Lock()
+	defer s.historyMutex.Unlock()
+	s.history = nil
+}
+
 // Returns the history lines starting with prefix
 func (s *State) getHistoryByPrefix(prefix string) (ph []string) {
 	for _, h := range s.history {

--- a/line_test.go
+++ b/line_test.go
@@ -71,6 +71,15 @@ dingle`
 		t.Fatal("Round-trip failure")
 	}
 
+	// clear the history and re-write
+	s.ClearHistory()
+	num, err = s.WriteHistory(&out)
+	if err != nil {
+		t.Fatal("Unexpected error writing history", err)
+	}
+	if num != 0 {
+		t.Fatal("Wrong number of history entries written, expected none")
+	}
 	// Test reading with a trailing newline present
 	var s2 State
 	num, err = s2.ReadHistory(&out)


### PR DESCRIPTION
ClearHistory along with Read/WriteHistory can be used if implementing
modal prompts to provide a unique history per command sets.
