### PR TITLE
Return an error when the terminal reports zero columns and is refreshed

### DIFF
--- a/common.go
+++ b/common.go
@@ -64,6 +64,10 @@ var ErrNotTerminalOutput = errors.New("standard output is not a terminal")
 // be colour codes on some platforms).
 var ErrInvalidPrompt = errors.New("invalid prompt")
 
+// ErrPromptUnsupported is returned when a prompt cannot be used within the
+// current terminal.
+var ErrPromptUnsupported = errors.New("prompt unsupported")
+
 // KillRingMax is the max number of elements to save on the killring.
 const KillRingMax = 60
 

--- a/line.go
+++ b/line.go
@@ -90,6 +90,10 @@ const (
 )
 
 func (s *State) refresh(prompt []rune, buf []rune, pos int) error {
+	if s.columns == 0 {
+		return ErrPromptUnsupported
+	}
+
 	s.needRefresh = false
 	if s.multiLineMode {
 		return s.refreshMultiLine(prompt, buf, pos)
@@ -624,7 +628,9 @@ mainLoop:
 			switch v {
 			case cr, lf:
 				if s.needRefresh {
-					s.refresh(p, line, pos)
+					if err := s.refresh(p, line, pos); err != nil {
+						return "", err
+					}
 				}
 				if s.multiLineMode {
 					s.resetMultiLine(p, line, pos)


### PR DESCRIPTION
When used within a call to `docker exec -it` where the original
container does not have a TTY allocated to it (such as in
docker/docker#8755), the number of columns read from the `ioctl()` call
will be zero, but it will not return an error. If you call `Prompt()` or
`PasswordPrompt()` after this, the prompt will panic when it tries to
divide a number by the number of columns (which is zero).

This change detects when the number of columns returned is zero and
returns `ErrPromptUnsupported` from the `PromptXXX` methods to avoid a
panic and so the application is able to deal with the problem more
easily.