### PR TITLE
Check winch before prompt.

### DIFF
--- a/line.go
+++ b/line.go
@@ -595,6 +595,14 @@ func (s *State) PromptWithSuggestion(prompt string, text string, pos int) (strin
 	if s.inputRedirected || !s.terminalSupported {
 		return s.promptUnsupported(prompt)
 	}
+
+	select {
+	case <-s.winch:
+		// resize happened before prompt -- update columns for tooNarrow check
+		s.getColumns()
+	default:
+	}
+
 	p := []rune(prompt)
 	const minWorkingSpace = 10
 	if s.columns < countGlyphs(p)+minWorkingSpace {


### PR DESCRIPTION
If the terminal starts out too narrow, liner never invokes `s.readNext`
meaning that it will never receive the SIGWINCH to indicate that the
terminal has been resized (and doesn't call `s.getColumns` otherwise).
This patch checks the channel before doing the too narrow check and
updates the column size, if there was an update.

Future improvement would be to detect SIGWINCH in `s.tooNarrow` and
abort `s.promptUnsupported`.