### PR TITLE
Fix for #98

### DIFF
--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -55,3 +55,5 @@ func (n noopMode) ApplyMode() error {
 func TerminalMode() (ModeApplier, error) {
 	return noopMode{}, nil
 }
+
+const cursorColumn = true

--- a/input_windows.go
+++ b/input_windows.go
@@ -189,9 +189,6 @@ func (s *State) readNext() (interface{}, error) {
 		if input.eventType == window_buffer_size_event {
 			xy := (*coord)(unsafe.Pointer(&input.blob[0]))
 			s.columns = int(xy.x)
-			if s.columns > 1 {
-				s.columns--
-			}
 			return winch, nil
 		}
 		if input.eventType != key_event {
@@ -363,3 +360,5 @@ func TerminalMode() (ModeApplier, error) {
 	}
 	return mode, err
 }
+
+const cursorColumn = true

--- a/line.go
+++ b/line.go
@@ -113,6 +113,10 @@ func (s *State) refreshSingleLine(prompt []rune, buf []rune, pos int) error {
 
 	pLen := countGlyphs(prompt)
 	bLen := countGlyphs(buf)
+	// on some OS / terminals extra column is needed to place the cursor char
+	if cursorColumn {
+		bLen++
+	}
 	pos = countGlyphs(buf[:pos])
 	if pLen+bLen < s.columns {
 		_, err = fmt.Print(string(buf))
@@ -163,6 +167,14 @@ func (s *State) refreshSingleLine(prompt []rune, buf []rune, pos int) error {
 func (s *State) refreshMultiLine(prompt []rune, buf []rune, pos int) error {
 	promptColumns := countMultiLineGlyphs(prompt, s.columns, 0)
 	totalColumns := countMultiLineGlyphs(buf, s.columns, promptColumns)
+	// on some OS / terminals extra column is needed to place the cursor char
+	// if cursorColumn {
+	//	totalColumns++
+	// }
+
+	// it looks like Multiline mode always assume that a cursor need an extra column,
+	// and always emit a newline if we are at the screen end, so no worarounds needed there
+
 	totalRows := (totalColumns + s.columns - 1) / s.columns
 	maxRows := s.maxRows
 	if totalRows > s.maxRows {

--- a/output.go
+++ b/output.go
@@ -56,9 +56,6 @@ func (s *State) getColumns() bool {
 		return false
 	}
 	s.columns = int(ws.col)
-	if cursorColumn && s.columns > 1 {
-		s.columns--
-	}
 	return true
 }
 

--- a/output_windows.go
+++ b/output_windows.go
@@ -69,8 +69,4 @@ func (s *State) getColumns() {
 	var sbi consoleScreenBufferInfo
 	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
 	s.columns = int(sbi.dwSize.x)
-	if s.columns > 1 {
-		// Windows 10 needs a spare column for the cursor
-		s.columns--
-	}
 }


### PR DESCRIPTION
Changing the approach of fixing https://github.com/peterh/liner/issues/71
(introduced by 0e4af131b90a9786839c8b1b01717be263e8555a).

Instead of 'decreasing' screen width for cases when cursor take extra column, increment the calculated user input length.

With correct screen width multiline mode works properly.