### PR TITLE
Add key binding Alt+BackSpace to delete word leading up to cursor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Ctrl-C       | Reset input (create new empty prompt)
 Ctrl-L       | Clear screen (line is unmodified)
 Ctrl-T       | Transpose previous character with current character
 Ctrl-H, BackSpace | Delete character before cursor
-Ctrl-W       | Delete word leading up to cursor
+Ctrl-W, Alt-BackSpace | Delete word leading up to cursor
+Alt-D        | Delete word following cursor
 Ctrl-K       | Delete from cursor to end of line
 Ctrl-U       | Delete from start of line to cursor
 Ctrl-P, Up   | Previous match from history

--- a/input.go
+++ b/input.go
@@ -331,6 +331,9 @@ func (s *State) readNext() (interface{}, error) {
 	case 'd':
 		s.pending = s.pending[:0] // escape code complete
 		return altD, nil
+	case bs:
+		s.pending = s.pending[:0] // escape code complete
+		return altBs, nil
 	case 'f':
 		s.pending = s.pending[:0] // escape code complete
 		return altF, nil


### PR DESCRIPTION
Alt+BackSpace is the default key binding in bash to delete word leading up to cursor.