### PR TITLE
Async control, may fix #16 #46

### DIFF
--- a/actrl.go
+++ b/actrl.go
@@ -13,7 +13,25 @@ func (s *State) Done() chan struct{} {
 	return s.done
 }
 
-func (s *State) performAction(actReq action) {
+type actCode int
+
+const (
+	noAct actCode = iota
+
+	hidePrompt
+	showPrompt
+	chgPrompt
+)
+
+type asyncAction struct {
+	act  actCode
+	data interface{}
+}
+
+func (s *State) performAction(act actCode, data interface{}) {
+	actReq := &asyncAction{
+		act, data,
+	}
 	select {
 	case s.actIn <- actReq:
 		// the requested action went into prompting function
@@ -32,11 +50,17 @@ func (s *State) performAction(actReq action) {
 // HidePrompt returns after the prompt and partial input is cleared if under line editing,
 // or returns immediately if no editing undergoing.
 func (s *State) HidePrompt() {
-	s.performAction(hidePrompt)
+	s.performAction(hidePrompt, nil)
 }
 
 // ShowPrompt returns after the prompt and partial input is refreshed if under line editing,
 // or returns immediately if no editing undergoing.
 func (s *State) ShowPrompt() {
-	s.performAction(showPrompt)
+	s.performAction(showPrompt, nil)
+}
+
+// ChangePrompt change the prompt and restore partial input if under line editing,
+// or returns immediately if no editing undergoing.
+func (s *State) ChangePrompt(prompt string) {
+	s.performAction(chgPrompt, prompt)
 }

--- a/actrl.go
+++ b/actrl.go
@@ -1,0 +1,42 @@
+package liner
+
+// Done returns a closed channel if not editing,
+// or an open channel that will be closed when editing is done.
+func (s *State) Done() chan struct{} {
+	s.doneMutex.Lock()
+	defer s.doneMutex.Unlock()
+
+	if s.done == nil {
+		s.done = make(chan struct{})
+		close(s.done)
+	}
+	return s.done
+}
+
+func (s *State) performAction(actReq action) {
+	select {
+	case s.actIn <- actReq:
+		// the requested action went into prompting function
+		for {
+			// todo dead waiting possibile here ? need to add timeout etc. ?
+			if actDid := <-s.actOut; actDid == actReq {
+				return
+			}
+		}
+	case <-s.Done():
+		// not editing
+		return
+	}
+}
+
+// HidePrompt returns after the prompt and partial input is cleared if under line editing,
+// or returns immediately if no editing undergoing.
+func (s *State) HidePrompt() {
+	s.performAction(hidePrompt)
+}
+
+// ShowPrompt returns after the prompt and partial input is refreshed if under line editing,
+// or returns immediately if no editing undergoing.
+func (s *State) ShowPrompt() {
+	s.performAction(showPrompt)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/peterh/liner
+module github.com/complyue/liner
 
 require github.com/mattn/go-runewidth v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/complyue/liner
+module github.com/peterh/liner
 
 require github.com/mattn/go-runewidth v0.0.3

--- a/input.go
+++ b/input.go
@@ -158,7 +158,7 @@ func (s *State) readNext() (interface{}, error) {
 	case <-s.winch:
 		s.getColumns()
 		return winch, nil
-	case actReq := <-s.ctrlIn:
+	case actReq := <-s.actIn:
 		return actReq, nil
 	}
 	if r != esc {

--- a/input.go
+++ b/input.go
@@ -29,7 +29,7 @@ type State struct {
 	pending     []rune
 	useCHA      bool
 
-	actIn, actOut chan action
+	actIn, actOut chan *asyncAction
 
 	done      chan struct{}
 	doneMutex sync.Mutex
@@ -38,7 +38,10 @@ type State struct {
 // NewLiner initializes a new *State, and sets the terminal into raw mode. To
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
-	var s State
+	s := State{
+		actIn:  make(chan *asyncAction),
+		actOut: make(chan *asyncAction),
+	}
 	s.r = bufio.NewReader(os.Stdin)
 
 	s.terminalSupported = TerminalSupported()

--- a/line.go
+++ b/line.go
@@ -48,10 +48,6 @@ const (
 	wordLeft
 	wordRight
 	winch
-
-	hidePrompt
-	showPrompt
-
 	unknown
 )
 
@@ -996,15 +992,24 @@ mainLoop:
 					s.maxRows = 1
 					s.cursorRows = 1
 				}
+			}
+			s.needRefresh = true
+		case *asyncAction:
+			switch v.act {
 			case hidePrompt:
 				s.cursorPos(0)
 				s.eraseLine()
-				s.actOut <- hidePrompt
 			case showPrompt:
 				s.refresh(p, line, pos)
-				s.actOut <- showPrompt
+			case chgPrompt:
+				prompt = v.data.(string)
+				p = []rune(prompt)
+				// fmt.Printf(" ** chg p [%v] [%v] **\n", prompt, p)
+				s.cursorPos(0)
+				s.eraseLine()
+				s.refresh(p, line, pos)
 			}
-			s.needRefresh = true
+			s.actOut <- v
 		}
 		if s.needRefresh && !s.inputWaiting() {
 			err := s.refresh(p, line, pos)

--- a/line.go
+++ b/line.go
@@ -48,6 +48,10 @@ const (
 	wordLeft
 	wordRight
 	winch
+
+	hidePrompt
+	showPrompt
+
 	unknown
 )
 
@@ -992,6 +996,13 @@ mainLoop:
 					s.maxRows = 1
 					s.cursorRows = 1
 				}
+			case hidePrompt:
+				s.cursorPos(0)
+				s.eraseLine()
+				s.actOut <- hidePrompt
+			case showPrompt:
+				s.refresh(p, line, pos)
+				s.actOut <- showPrompt
 			}
 			s.needRefresh = true
 		}

--- a/line.go
+++ b/line.go
@@ -1004,7 +1004,6 @@ mainLoop:
 			case chgPrompt:
 				prompt = v.data.(string)
 				p = []rune(prompt)
-				// fmt.Printf(" ** chg p [%v] [%v] **\n", prompt, p)
 				s.cursorPos(0)
 				s.eraseLine()
 				s.refresh(p, line, pos)


### PR DESCRIPTION
This may fix #16 #46 and less racy, tho I don't know how it'll work on windows.


![a](https://user-images.githubusercontent.com/15646573/57455897-cd85ad80-729e-11e9-93e9-1a4b2368e32e.gif)



```go
	// fancy count down to test/showcase async control of liner
	he.ExposeFunction("sd", func(cnt int) string {
		go func() {

			for n := cnt; n > 0; n-- {
				line.ChangePrompt(fmt.Sprintf("SelfDtor(%d): ", n))

				time.Sleep(1 * time.Second)

				line.HidePrompt()
				fmt.Printf(" %d seconds passed.\n", 1+cnt-n)
				line.ShowPrompt()
			}
			line.HidePrompt()
			fmt.Println("Boom!!!")
			line.ShowPrompt()

			line.ChangePrompt("!!<defunct> ")
		}()

		return fmt.Sprintf("Self Destruction in %d seconds ...", cnt)
	})
```
