### PR TITLE
Make writer and reader configurable

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,6 +26,7 @@ type commonState struct {
 	columns           int
 	killRing          *ring.Ring
 	ctrlCAborts       bool
+	w                 io.Writer
 	r                 *bufio.Reader
 	tabStyle          TabStyle
 	multiLineMode     bool
@@ -245,11 +246,31 @@ func (s *State) SetShouldRestart(f ShouldRestart) {
 
 func (s *State) promptUnsupported(p string) (string, error) {
 	if !s.inputRedirected || !s.terminalSupported {
-		fmt.Print(p)
+		s.print(p)
 	}
 	linebuf, _, err := s.r.ReadLine()
 	if err != nil {
 		return "", err
 	}
 	return string(linebuf), nil
+}
+
+func (s *State) print(str string) (int, error) {
+	return fmt.Fprint(s.w, str)
+}
+
+func (s *State) println(args ...interface{}) (int, error) {
+	return fmt.Fprintln(s.w, args...)
+}
+
+func (s *State) printf(str string, args ...interface{}) (int, error) {
+	return fmt.Fprintf(s.w, str, args...)
+}
+
+func (s *State) SetWriter(w io.Writer) {
+	s.w = w
+}
+
+func (s *State) SetReader(r io.Reader) {
+	s.r = bufio.NewReader(r)
 }

--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"bufio"
 	"errors"
 	"os"
 )
@@ -30,7 +29,8 @@ func (s *State) PasswordPrompt(p string) (string, error) {
 // editing. Patches welcome.
 func NewLiner() *State {
 	var s State
-	s.r = bufio.NewReader(os.Stdin)
+	s.SetWriter(os.Stdout)
+	s.SetReader(os.Stdin)
 	return &s
 }
 

--- a/input.go
+++ b/input.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"bufio"
 	"errors"
 	"os"
 	"os/signal"
@@ -33,7 +32,8 @@ type State struct {
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
-	s.r = bufio.NewReader(os.Stdin)
+	s.SetWriter(os.Stdout)
+	s.SetReader(os.Stdin)
 
 	s.terminalSupported = TerminalSupported()
 	if m, err := TerminalMode(); err == nil {

--- a/input_test.go
+++ b/input_test.go
@@ -3,8 +3,8 @@
 package liner
 
 import (
-	"bufio"
 	"bytes"
+	"os"
 	"testing"
 )
 
@@ -39,7 +39,8 @@ func (s *State) expectAction(t *testing.T, a action) {
 func TestTypes(t *testing.T) {
 	input := []byte{'A', 27, 'B', 27, 91, 68, 27, '[', '1', ';', '5', 'D', 'e'}
 	var s State
-	s.r = bufio.NewReader(bytes.NewBuffer(input))
+	s.SetWriter(os.Stdout)
+	s.SetReader(bytes.NewBuffer(input))
 
 	next := make(chan nexter)
 	go func() {

--- a/input_windows.go
+++ b/input_windows.go
@@ -1,7 +1,6 @@
 package liner
 
 import (
-	"bufio"
 	"os"
 	"syscall"
 	"unicode/utf16"
@@ -57,6 +56,7 @@ const (
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
+	s.SetWriter(os.Stdout)
 	hIn, _, _ := procGetStdHandle.Call(uintptr(std_input_handle))
 	s.handle = syscall.Handle(hIn)
 	hOut, _, _ := procGetStdHandle.Call(uintptr(std_output_handle))
@@ -74,7 +74,7 @@ func NewLiner() *State {
 		mode.ApplyMode()
 	} else {
 		s.inputRedirected = true
-		s.r = bufio.NewReader(os.Stdin)
+		s.SetReader(os.Stdin)
 	}
 
 	s.getColumns()

--- a/line_test.go
+++ b/line_test.go
@@ -2,7 +2,7 @@ package liner
 
 import (
 	"bytes"
-	"fmt"
+	"os"
 	"strings"
 	"testing"
 )
@@ -129,6 +129,7 @@ func TestColumns(t *testing.T) {
 // history buffer without using a file.
 func ExampleState_WriteHistory() {
 	var s State
+	s.SetWriter(os.Stdout)
 	s.AppendHistory("foo")
 	s.AppendHistory("bar")
 
@@ -137,7 +138,7 @@ func ExampleState_WriteHistory() {
 	if err == nil {
 		history := strings.Split(strings.TrimSpace(buf.String()), "\n")
 		for i, line := range history {
-			fmt.Println("History entry", i, ":", line)
+			s.println("History entry", i, ":", line)
 		}
 	}
 	// Output:

--- a/output.go
+++ b/output.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"syscall"
@@ -13,34 +12,34 @@ import (
 func (s *State) cursorPos(x int) {
 	if s.useCHA {
 		// 'G' is "Cursor Character Absolute (CHA)"
-		fmt.Printf("\x1b[%dG", x+1)
+		s.printf("\x1b[%dG", x+1)
 	} else {
 		// 'C' is "Cursor Forward (CUF)"
-		fmt.Print("\r")
+		s.print("\r")
 		if x > 0 {
-			fmt.Printf("\x1b[%dC", x)
+			s.printf("\x1b[%dC", x)
 		}
 	}
 }
 
 func (s *State) eraseLine() {
-	fmt.Print("\x1b[0K")
+	s.print("\x1b[0K")
 }
 
 func (s *State) eraseScreen() {
-	fmt.Print("\x1b[H\x1b[2J")
+	s.print("\x1b[H\x1b[2J")
 }
 
 func (s *State) moveUp(lines int) {
-	fmt.Printf("\x1b[%dA", lines)
+	s.printf("\x1b[%dA", lines)
 }
 
 func (s *State) moveDown(lines int) {
-	fmt.Printf("\x1b[%dB", lines)
+	s.printf("\x1b[%dB", lines)
 }
 
 func (s *State) emitNewLine() {
-	fmt.Print("\n")
+	s.print("\n")
 }
 
 type winSize struct {


### PR DESCRIPTION
This pull request allows the library user to configure input reader and output writer.

- This allows the users to improve more testability.
- Also allows to configure the writer, especially to the tty output (using [go-tty](https://github.com/mattn/go-tty)), to distinguish the liner output and stdout.