### PR TITLE
Added a field and func to change the history limit.

### DIFF
--- a/input.go
+++ b/input.go
@@ -33,6 +33,7 @@ type State struct {
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
+	s.historyLimit = HistoryLimit
 	s.r = bufio.NewReader(os.Stdin)
 
 	s.terminalSupported = TerminalSupported()


### PR DESCRIPTION
I found that I needed *fewer* lines in the history for some projects, so I made it possible to change the limit. I think others might find use for it (even going beyond 1000, if they're weird). The constant is only used when creating the State struct, then an internal int is used referenced wherever the HistoryLimit constant used to be.