### PR TITLE
Implement NewLinerTTY for using liner connecting tty regardless of redirections

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,6 +26,7 @@ type commonState struct {
 	columns           int
 	killRing          *ring.Ring
 	ctrlCAborts       bool
+	w                 io.Writer
 	r                 *bufio.Reader
 	tabStyle          TabStyle
 	multiLineMode     bool
@@ -252,11 +253,31 @@ func (s *State) SetBeep(beep bool) {
 
 func (s *State) promptUnsupported(p string) (string, error) {
 	if !s.inputRedirected || !s.terminalSupported {
-		fmt.Print(p)
+		s.print(p)
 	}
 	linebuf, _, err := s.r.ReadLine()
 	if err != nil {
 		return "", err
 	}
 	return string(linebuf), nil
+}
+
+func (s *State) print(str string) (int, error) {
+	return fmt.Fprint(s.w, str)
+}
+
+func (s *State) println(args ...interface{}) (int, error) {
+	return fmt.Fprintln(s.w, args...)
+}
+
+func (s *State) printf(str string, args ...interface{}) (int, error) {
+	return fmt.Fprintf(s.w, str, args...)
+}
+
+func (s *State) SetWriter(w io.Writer) {
+	s.w = w
+}
+
+func (s *State) SetReader(r io.Reader) {
+	s.r = bufio.NewReader(r)
 }

--- a/common.go
+++ b/common.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"unicode/utf8"
+
+	"github.com/mattn/go-tty"
 )
 
 type commonState struct {
@@ -78,6 +80,33 @@ const KillRingMax = 60
 
 // HistoryLimit is the maximum number of entries saved in the scrollback history.
 const HistoryLimit = 1000
+
+// NewLiner initializes a new *State, and sets the terminal into raw mode. To
+// restore the terminal to its previous state, call State.Close().
+func NewLiner() *State {
+	var s State
+	s.setWriter(os.Stdout)
+	s.setReader(os.Stdin)
+	s.init()
+	return &s
+}
+
+// NewLinerTTY initializes a new *State with connecting to tty.
+// This is useful when prompting regardless of the redirections.
+func NewLinerTTY() *State {
+	var s State
+	tty, err := tty.Open()
+	if err == nil {
+		s.setWriter(tty.Output())
+		s.setReader(tty.Input())
+		s.tty = tty
+	} else {
+		s.setWriter(os.Stdout)
+		s.setReader(os.Stdin)
+	}
+	s.init()
+	return &s
+}
 
 // ReadHistory reads scrollback history from r. Returns the number of lines
 // read, and any read error (except io.EOF).

--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -29,8 +29,8 @@ func (s *State) PasswordPrompt(p string) (string, error) {
 // editing. Patches welcome.
 func NewLiner() *State {
 	var s State
-	s.SetWriter(os.Stdout)
-	s.SetReader(os.Stdin)
+	s.setWriter(os.Stdout)
+	s.setReader(os.Stdin)
 	return &s
 }
 
@@ -47,12 +47,12 @@ func TerminalSupported() bool {
 
 type noopMode struct{}
 
-func (n noopMode) ApplyMode() error {
+func (n noopMode) ApplyMode(uintptr) error {
 	return nil
 }
 
 // TerminalMode returns a noop InputModeSetter on this platform.
-func TerminalMode() (ModeApplier, error) {
+func (s *State) TerminalMode() (ModeApplier, error) {
 	return noopMode{}, nil
 }
 

--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -4,7 +4,6 @@ package liner
 
 import (
 	"errors"
-	"os"
 )
 
 // State represents an open terminal
@@ -23,15 +22,7 @@ func (s *State) PasswordPrompt(p string) (string, error) {
 	return "", errors.New("liner: function not supported in this terminal")
 }
 
-// NewLiner initializes a new *State
-//
-// Note that this operating system uses a fallback mode without line
-// editing. Patches welcome.
-func NewLiner() *State {
-	var s State
-	s.setWriter(os.Stdout)
-	s.setReader(os.Stdin)
-	return &s
+func (s *State) init() {
 }
 
 // Close returns the terminal to its previous mode

--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"bufio"
 	"errors"
 	"os"
 )
@@ -30,7 +29,8 @@ func (s *State) PasswordPrompt(p string) (string, error) {
 // editing. Patches welcome.
 func NewLiner() *State {
 	var s State
-	s.r = bufio.NewReader(os.Stdin)
+	s.SetWriter(os.Stdout)
+	s.SetReader(os.Stdin)
 	return &s
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/peterh/liner
 
+go 1.13
+
 require (
 	github.com/mattn/go-runewidth v0.0.6
 	github.com/mattn/go-tty v0.0.3
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/peterh/liner
 
-require github.com/mattn/go-runewidth v0.0.3
+require (
+	github.com/mattn/go-runewidth v0.0.6
+	github.com/mattn/go-tty v0.0.3
+)
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
-github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
-github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-runewidth v0.0.6 h1:V2iyH+aX9C5fsYCpK60U8BYIvmhqxuOL3JZcqc1NB7k=
+github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-tty v0.0.3 h1:5OfyWorkyO7xP52Mq7tB36ajHDG5OHrmBGIS/DtakQI=
+github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/input.go
+++ b/input.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"bufio"
 	"errors"
 	"os"
 	"os/signal"
@@ -33,7 +32,8 @@ type State struct {
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
-	s.r = bufio.NewReader(os.Stdin)
+	s.SetWriter(os.Stdout)
+	s.SetReader(os.Stdin)
 
 	s.terminalSupported = TerminalSupported()
 	if m, err := TerminalMode(); err == nil {

--- a/input.go
+++ b/input.go
@@ -36,6 +36,16 @@ type State struct {
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
+	s.setWriter(os.Stdout)
+	s.setReader(os.Stdin)
+	s.init()
+	return &s
+}
+
+// NewLinerTTY initializes a new *State with connecting to tty.
+// This is useful when prompting regardless of the redirections.
+func NewLinerTTY() *State {
+	var s State
 	tty, err := tty.Open()
 	if err == nil {
 		s.setWriter(tty.Output())
@@ -45,7 +55,11 @@ func NewLiner() *State {
 		s.setWriter(os.Stdout)
 		s.setReader(os.Stdin)
 	}
+	s.init()
+	return &s
+}
 
+func (s *State) init() {
 	s.terminalSupported = TerminalSupported()
 	if m, err := s.TerminalMode(); err == nil {
 		s.origMode = *m.(*termios)
@@ -75,8 +89,6 @@ func NewLiner() *State {
 	if !s.outputRedirected {
 		s.outputRedirected = !s.getColumns()
 	}
-
-	return &s
 }
 
 var errTimedOut = errors.New("timeout")

--- a/input.go
+++ b/input.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/mattn/go-tty"
 )
 
 type nexter struct {
@@ -30,33 +28,6 @@ type State struct {
 	pending     []rune
 	useCHA      bool
 	tty         io.Closer
-}
-
-// NewLiner initializes a new *State, and sets the terminal into raw mode. To
-// restore the terminal to its previous state, call State.Close().
-func NewLiner() *State {
-	var s State
-	s.setWriter(os.Stdout)
-	s.setReader(os.Stdin)
-	s.init()
-	return &s
-}
-
-// NewLinerTTY initializes a new *State with connecting to tty.
-// This is useful when prompting regardless of the redirections.
-func NewLinerTTY() *State {
-	var s State
-	tty, err := tty.Open()
-	if err == nil {
-		s.setWriter(tty.Output())
-		s.setReader(tty.Input())
-		s.tty = tty
-	} else {
-		s.setWriter(os.Stdout)
-		s.setReader(os.Stdin)
-	}
-	s.init()
-	return &s
 }
 
 func (s *State) init() {

--- a/input_test.go
+++ b/input_test.go
@@ -3,8 +3,8 @@
 package liner
 
 import (
-	"bufio"
 	"bytes"
+	"os"
 	"testing"
 )
 
@@ -39,7 +39,8 @@ func (s *State) expectAction(t *testing.T, a action) {
 func TestTypes(t *testing.T) {
 	input := []byte{'A', 27, 'B', 27, 91, 68, 27, '[', '1', ';', '5', 'D', 'e'}
 	var s State
-	s.r = bufio.NewReader(bytes.NewBuffer(input))
+	s.SetWriter(os.Stdout)
+	s.SetReader(bytes.NewBuffer(input))
 
 	next := make(chan nexter)
 	go func() {

--- a/input_test.go
+++ b/input_test.go
@@ -39,8 +39,8 @@ func (s *State) expectAction(t *testing.T, a action) {
 func TestTypes(t *testing.T) {
 	input := []byte{'A', 27, 'B', 27, 91, 68, 27, '[', '1', ';', '5', 'D', 'e'}
 	var s State
-	s.SetWriter(os.Stdout)
-	s.SetReader(bytes.NewBuffer(input))
+	s.setWriter(os.Stdout)
+	s.setReader(bytes.NewBuffer(input))
 
 	next := make(chan nexter)
 	go func() {

--- a/input_windows.go
+++ b/input_windows.go
@@ -2,7 +2,6 @@ package liner
 
 import (
 	"io"
-	"os"
 	"syscall"
 	"unicode/utf16"
 	"unsafe"
@@ -55,7 +54,6 @@ func (s *State) init() {
 		mode.ApplyMode(s.infd)
 	} else {
 		s.inputRedirected = true
-		s.setReader(os.Stdin)
 	}
 
 	s.getColumns()

--- a/input_windows.go
+++ b/input_windows.go
@@ -56,7 +56,7 @@ const (
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
-	s.SetWriter(os.Stdout)
+	s.setWriter(os.Stdout)
 	hIn, _, _ := procGetStdHandle.Call(uintptr(std_input_handle))
 	s.handle = syscall.Handle(hIn)
 	hOut, _, _ := procGetStdHandle.Call(uintptr(std_output_handle))
@@ -74,7 +74,7 @@ func NewLiner() *State {
 		mode.ApplyMode()
 	} else {
 		s.inputRedirected = true
-		s.SetReader(os.Stdin)
+		s.setReader(os.Stdin)
 	}
 
 	s.getColumns()

--- a/input_windows.go
+++ b/input_windows.go
@@ -1,7 +1,6 @@
 package liner
 
 import (
-	"bufio"
 	"os"
 	"syscall"
 	"unicode/utf16"
@@ -57,6 +56,7 @@ const (
 // restore the terminal to its previous state, call State.Close().
 func NewLiner() *State {
 	var s State
+	s.SetWriter(os.Stdout)
 	hIn, _, _ := procGetStdHandle.Call(uintptr(std_input_handle))
 	s.handle = syscall.Handle(hIn)
 	hOut, _, _ := procGetStdHandle.Call(uintptr(std_output_handle))
@@ -74,7 +74,7 @@ func NewLiner() *State {
 		mode.ApplyMode()
 	} else {
 		s.inputRedirected = true
-		s.r = bufio.NewReader(os.Stdin)
+		s.SetReader(os.Stdin)
 	}
 
 	s.getColumns()

--- a/line.go
+++ b/line.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -1128,11 +1127,6 @@ func (s *State) tooNarrow(prompt string) (string, error) {
 	s.origMode.ApplyMode(s.infd)
 	if merr == nil {
 		defer m.ApplyMode(s.infd)
-	}
-	if s.r == nil {
-		// Windows does not always set s.r
-		s.setReader(os.Stdin)
-		defer func() { s.r = nil }()
 	}
 	return s.promptUnsupported(prompt)
 }

--- a/line.go
+++ b/line.go
@@ -1124,14 +1124,14 @@ func (s *State) tooNarrow(prompt string) (string, error) {
 	// Docker and OpenWRT and etc sometimes return 0 column width
 	// Reset mode temporarily. Restore baked mode in case the terminal
 	// is wide enough for the next Prompt attempt.
-	m, merr := TerminalMode()
-	s.origMode.ApplyMode()
+	m, merr := s.TerminalMode()
+	s.origMode.ApplyMode(s.infd)
 	if merr == nil {
-		defer m.ApplyMode()
+		defer m.ApplyMode(s.infd)
 	}
 	if s.r == nil {
 		// Windows does not always set s.r
-		s.SetReader(os.Stdin)
+		s.setReader(os.Stdin)
 		defer func() { s.r = nil }()
 	}
 	return s.promptUnsupported(prompt)

--- a/line_test.go
+++ b/line_test.go
@@ -129,7 +129,7 @@ func TestColumns(t *testing.T) {
 // history buffer without using a file.
 func ExampleState_WriteHistory() {
 	var s State
-	s.SetWriter(os.Stdout)
+	s.setWriter(os.Stdout)
 	s.AppendHistory("foo")
 	s.AppendHistory("bar")
 

--- a/line_test.go
+++ b/line_test.go
@@ -2,7 +2,7 @@ package liner
 
 import (
 	"bytes"
-	"fmt"
+	"os"
 	"strings"
 	"testing"
 )
@@ -129,6 +129,7 @@ func TestColumns(t *testing.T) {
 // history buffer without using a file.
 func ExampleState_WriteHistory() {
 	var s State
+	s.SetWriter(os.Stdout)
 	s.AppendHistory("foo")
 	s.AppendHistory("bar")
 
@@ -137,7 +138,7 @@ func ExampleState_WriteHistory() {
 	if err == nil {
 		history := strings.Split(strings.TrimSpace(buf.String()), "\n")
 		for i, line := range history {
-			fmt.Println("History entry", i, ":", line)
+			s.println("History entry", i, ":", line)
 		}
 	}
 	// Output:

--- a/output.go
+++ b/output.go
@@ -3,7 +3,6 @@
 package liner
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"syscall"
@@ -13,34 +12,34 @@ import (
 func (s *State) cursorPos(x int) {
 	if s.useCHA {
 		// 'G' is "Cursor Character Absolute (CHA)"
-		fmt.Printf("\x1b[%dG", x+1)
+		s.printf("\x1b[%dG", x+1)
 	} else {
 		// 'C' is "Cursor Forward (CUF)"
-		fmt.Print("\r")
+		s.print("\r")
 		if x > 0 {
-			fmt.Printf("\x1b[%dC", x)
+			s.printf("\x1b[%dC", x)
 		}
 	}
 }
 
 func (s *State) eraseLine() {
-	fmt.Print("\x1b[0K")
+	s.print("\x1b[0K")
 }
 
 func (s *State) eraseScreen() {
-	fmt.Print("\x1b[H\x1b[2J")
+	s.print("\x1b[H\x1b[2J")
 }
 
 func (s *State) moveUp(lines int) {
-	fmt.Printf("\x1b[%dA", lines)
+	s.printf("\x1b[%dA", lines)
 }
 
 func (s *State) moveDown(lines int) {
-	fmt.Printf("\x1b[%dB", lines)
+	s.printf("\x1b[%dB", lines)
 }
 
 func (s *State) emitNewLine() {
-	fmt.Print("\n")
+	s.print("\n")
 }
 
 type winSize struct {

--- a/output.go
+++ b/output.go
@@ -49,7 +49,7 @@ type winSize struct {
 
 func (s *State) getColumns() bool {
 	var ws winSize
-	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdout),
+	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, s.outfd,
 		syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws)))
 	if int(ok) < 0 {
 		return false

--- a/output_windows.go
+++ b/output_windows.go
@@ -21,16 +21,16 @@ type consoleScreenBufferInfo struct {
 
 func (s *State) cursorPos(x int) {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
-	procSetConsoleCursorPosition.Call(uintptr(s.hOut),
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
+	procSetConsoleCursorPosition.Call(s.outfd,
 		uintptr(int(x)&0xFFFF|int(sbi.dwCursorPosition.y)<<16))
 }
 
 func (s *State) eraseLine() {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
 	var numWritten uint32
-	procFillConsoleOutputCharacter.Call(uintptr(s.hOut), uintptr(' '),
+	procFillConsoleOutputCharacter.Call(s.outfd, uintptr(' '),
 		uintptr(sbi.dwSize.x-sbi.dwCursorPosition.x),
 		uintptr(int(sbi.dwCursorPosition.x)&0xFFFF|int(sbi.dwCursorPosition.y)<<16),
 		uintptr(unsafe.Pointer(&numWritten)))
@@ -38,26 +38,26 @@ func (s *State) eraseLine() {
 
 func (s *State) eraseScreen() {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
 	var numWritten uint32
-	procFillConsoleOutputCharacter.Call(uintptr(s.hOut), uintptr(' '),
+	procFillConsoleOutputCharacter.Call(s.outfd, uintptr(' '),
 		uintptr(sbi.dwSize.x)*uintptr(sbi.dwSize.y),
 		0,
 		uintptr(unsafe.Pointer(&numWritten)))
-	procSetConsoleCursorPosition.Call(uintptr(s.hOut), 0)
+	procSetConsoleCursorPosition.Call(s.outfd, 0)
 }
 
 func (s *State) moveUp(lines int) {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
-	procSetConsoleCursorPosition.Call(uintptr(s.hOut),
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
+	procSetConsoleCursorPosition.Call(s.outfd,
 		uintptr(int(sbi.dwCursorPosition.x)&0xFFFF|(int(sbi.dwCursorPosition.y)-lines)<<16))
 }
 
 func (s *State) moveDown(lines int) {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
-	procSetConsoleCursorPosition.Call(uintptr(s.hOut),
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
+	procSetConsoleCursorPosition.Call(s.outfd,
 		uintptr(int(sbi.dwCursorPosition.x)&0xFFFF|(int(sbi.dwCursorPosition.y)+lines)<<16))
 }
 
@@ -67,6 +67,6 @@ func (s *State) emitNewLine() {
 
 func (s *State) getColumns() {
 	var sbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(s.hOut), uintptr(unsafe.Pointer(&sbi)))
+	procGetConsoleScreenBufferInfo.Call(s.outfd, uintptr(unsafe.Pointer(&sbi)))
 	s.columns = int(sbi.dwSize.x)
 }

--- a/unixmode.go
+++ b/unixmode.go
@@ -7,8 +7,8 @@ import (
 	"unsafe"
 )
 
-func (mode *termios) ApplyMode() error {
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), setTermios, uintptr(unsafe.Pointer(mode)))
+func (mode *termios) ApplyMode(fd uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(mode)))
 
 	if errno != 0 {
 		return errno
@@ -20,18 +20,17 @@ func (mode *termios) ApplyMode() error {
 //
 // This function is provided for convenience, and should
 // not be necessary for most users of liner.
-func TerminalMode() (ModeApplier, error) {
-	mode, errno := getMode(syscall.Stdin)
-
+func (s *State) TerminalMode() (ModeApplier, error) {
+	mode, errno := getMode(s.infd)
 	if errno != 0 {
 		return nil, errno
 	}
 	return mode, nil
 }
 
-func getMode(handle int) (*termios, syscall.Errno) {
+func getMode(fd uintptr) (*termios, syscall.Errno) {
 	var mode termios
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(handle), getTermios, uintptr(unsafe.Pointer(&mode)))
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, getTermios, uintptr(unsafe.Pointer(&mode)))
 
 	return &mode, errno
 }


### PR DESCRIPTION
Currently liner changes the behavior based on redirections. This is sometimes useful to support both terminal input and pipe input, but is troublesome when I want to use always from terminal. I want to accept user's input from tty without breaking both stdin and stdout.
This pull request introduces new function NewLinerTTY for connecting both input and output to tty so that we can use liner regardless of the redirections. Note that months ago I submitted #121 however this was insufficient.