### PR TITLE
Update github.com/mattn/go-runewidth to v0.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/peterh/liner
 
-require github.com/mattn/go-runewidth v0.0.3
+go 1.14
+
+require github.com/mattn/go-runewidth v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=


### PR DESCRIPTION
It would be great to use the improvements from go-runewidth. All tests still run fine.