### PR TITLE
Add SetCtrlZStop

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,6 +26,7 @@ type commonState struct {
 	columns           int
 	killRing          *ring.Ring
 	ctrlCAborts       bool
+	ctrlZStop         bool
 	r                 *bufio.Reader
 	tabStyle          TabStyle
 	multiLineMode     bool
@@ -227,6 +228,12 @@ type ModeApplier interface {
 // (and Prompt does not return) regardless of the value passed to SetCtrlCAborts.
 func (s *State) SetCtrlCAborts(aborts bool) {
 	s.ctrlCAborts = aborts
+}
+
+// SetCtrlZStop sets whether Prompt on a supported terminal will send
+// SIGTSTP when Ctrl-Z is pressed. The default is false
+func (s *State) SetCtrlZStop(stop bool) {
+	s.ctrlZStop = stop
 }
 
 // SetMultiLineMode sets whether line is auto-wrapped. The default is false (single line).

--- a/line.go
+++ b/line.go
@@ -792,6 +792,8 @@ mainLoop:
 				pos = 0
 				fmt.Print(prompt)
 				s.restartPrompt()
+			case ctrlZ:
+				handleCtrZ()
 			case ctrlH, bs: // Backspace
 				if pos <= 0 {
 					s.doBeep()
@@ -828,7 +830,7 @@ mainLoop:
 			case esc:
 				// DO NOTHING
 			// Unused keys
-			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX, ctrlZ:
+			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:
@@ -1089,9 +1091,11 @@ mainLoop:
 				pos = 0
 				fmt.Print(prompt)
 				s.restartPrompt()
+			case ctrlZ:
+				handleCtrZ()
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,
-				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY, ctrlZ:
+				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,0 +1,15 @@
+// +build linux darwin openbsd freebsd netbsd
+
+package liner
+
+import (
+	"os"
+	"syscall"
+)
+
+func handleCtrZ() {
+	p, err := os.FindProcess(os.Getpid())
+	if err == nil {
+		p.Signal(syscall.SIGTSTP)
+	}
+}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,0 +1,3 @@
+package liner
+
+func handleCtrZ() {}


### PR DESCRIPTION
SetCtrlZStop can be called if the application wishes Prompt to
stop itself when when the user presses Ctrl-Z.

Fixes #131