### PR TITLE
Add functional options to bring your own stdin writer

### DIFF
--- a/common.go
+++ b/common.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -34,6 +35,16 @@ type commonState struct {
 	shouldRestart     ShouldRestart
 	noBeep            bool
 	needRefresh       bool
+}
+
+// Option is optional configuration for State.
+type Option func(*State)
+
+// WithStdin specifies a stdin to use.
+func WithStdin(r io.Reader) Option {
+	return func(s *State) {
+		s.r = bufio.NewReader(os.Stdin)
+	}
 }
 
 // TabStyle is used to select how tab completions are displayed.

--- a/fallbackinput.go
+++ b/fallbackinput.go
@@ -29,9 +29,12 @@ func (s *State) PasswordPrompt(p string) (string, error) {
 //
 // Note that this operating system uses a fallback mode without line
 // editing. Patches welcome.
-func NewLiner() *State {
+func NewLiner(opts ...Option) *State {
 	var s State
 	s.r = bufio.NewReader(os.Stdin)
+	for _, opt := range opts {
+		opt(&s)
+	}
 	return &s
 }
 

--- a/input.go
+++ b/input.go
@@ -32,7 +32,7 @@ type State struct {
 
 // NewLiner initializes a new *State, and sets the terminal into raw mode. To
 // restore the terminal to its previous state, call State.Close().
-func NewLiner() *State {
+func NewLiner(opts ...Option) *State {
 	var s State
 	s.r = bufio.NewReader(os.Stdin)
 
@@ -68,6 +68,9 @@ func NewLiner() *State {
 		s.outputRedirected = !s.getColumns()
 	}
 
+	for _, opt := range opts {
+		opt(&s)
+	}
 	return &s
 }
 

--- a/input_windows.go
+++ b/input_windows.go
@@ -55,7 +55,7 @@ const (
 
 // NewLiner initializes a new *State, and sets the terminal into raw mode. To
 // restore the terminal to its previous state, call State.Close().
-func NewLiner() *State {
+func NewLiner(opts ...Option) *State {
 	var s State
 	hIn, _, _ := procGetStdHandle.Call(uintptr(std_input_handle))
 	s.handle = syscall.Handle(hIn)
@@ -80,6 +80,9 @@ func NewLiner() *State {
 	s.getColumns()
 	s.outputRedirected = s.columns <= 0
 
+	for _, opt := range opts {
+		opt(&s)
+	}
 	return &s
 }
 


### PR DESCRIPTION
I have a use case where I need to take back control of `os.Stdin` occasionally, so I would like to pass in my own `io.Writer`.